### PR TITLE
fix: fix parser error of xml based epub

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -25,6 +25,7 @@ Make bilingual epub books Using AI translate
 7. 加了 `--proxy` 参数，方便中国大陆的用户在本地测试时使用代理，传入类似 `http://127.0.0.1:7890` 的字符串
 8. 加入 `--resume` 命令，可以手动中断后，加入命令继续执行。
 9. 如果你遇到了墙需要用 Cloudflare Workers 替换 api_base 请使用 `--api_base ${url}` 来替换。**请注意，此处你输入的api应该是"`https://xxxx/v1`"的字样，域名需要用引号包裹**
+10. 如果你发现自己的 ePub 电子书是使用 xhtml 格式编写的，那么可以尝试使用 `--xhtml` 使用 xml parser
 
 e.g.
 ```shell

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Make bilingual epub books Using AI translate
 7. Use the --proxy parameter to enable users in mainland China to use a proxy when testing locally. Enter a string such as http://127.0.0.1:7890.
 8. Use the --resume command to manually resume the process after an interruption.
 9. If you want to change api_base like using Cloudflare Workers Use --api_base ${url} to support it. **Note: the api url you input should be `https://xxxx/v1', and quotation marks are required. **
+10. If you find that your ePub ebook is written in the XHTML format, you can try using --xhtml to use the XML parser.
 
 e.g.
 ```shell

--- a/make_book.py
+++ b/make_book.py
@@ -19,6 +19,7 @@ from utils import LANGUAGES, TO_LANGUAGE_CODE
 NO_LIMIT = False
 IS_TEST = False
 RESUME = False
+XHTML = False
 
 
 class Base:
@@ -162,9 +163,14 @@ class BEPUB:
         new_book.toc = self.origin_book.toc
         all_items = list(self.origin_book.get_items())
         # we just translate tag p
-        all_p_length = sum(
-            [len(bs(i.content, "html.parser").findAll("p")) for i in all_items]
-        )
+        if XHTML:
+            all_p_length = sum(
+                [len(bs(i.content, "xml").findAll("p")) for i in all_items]
+            )
+        else:
+            all_p_length = sum(
+                [len(bs(i.content, "html.parser").findAll("p")) for i in all_items]
+            )
         if IS_TEST:
             pbar = tqdm(total=TEST_NUM)
         else:
@@ -293,11 +299,19 @@ if __name__ == "__main__":
         type=str,
         help="replace base url from openapi",
     )
+    # args to use xml parser
+    parser.add_argument(
+        "--xhtml",
+        dest="xhtml",
+        action="store_true",
+        help="use xmlparser to parse epub",
+    )
 
     options = parser.parse_args()
     NO_LIMIT = options.no_limit
     IS_TEST = options.test
     TEST_NUM = options.test_num
+    XHTML = options.xhtml
     PROXY = options.proxy
     if PROXY != "":
         os.environ["http_proxy"] = PROXY

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 ebooklib
 rich
 tqdm
+lxml


### PR DESCRIPTION
I got an error at the begining because of beautiful soup parser. Because my epub book is written by xhtml , so the error occured.
I add a argument to fix the xhtml based epub.

我在使用过程中，启动阶段就出现了错误因为 bs 库的 parser。因为我的 EPUB 是用 xhtml 编写的。
加入了一个参数，用于 xhtml 格式的 epub。