### PR TITLE
feat: Change documentation on clearifying model usage

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,4 +1,4 @@
-# bilingual_book_maker
+tw# bilingual_book_maker
 Make bilingual epub books Using AI translate
 
 ![image](https://user-images.githubusercontent.com/15976103/222317531-a05317c5-4eee-49de-95cd-04063d9539d9.png)
@@ -17,7 +17,7 @@ Make bilingual epub books Using AI translate
 1. pip install -r requirements.txt
 2. OpenAI API key，如果有多个可以用英文逗号分隔(xxx,xxx,xxx)，可以减少接口调用次数限制带来的错误
 3. 本地放了一个 animal_farm.epub 给大家测试
-4. 默认用了 ChatGPT 模型，用 `--model gpt3` 来使用 gpt3 模型
+4. 默认用了 [GPT-3.5-turbo](https://openai.com/blog/introducing-chatgpt-and-whisper-apis) 模型，也就是 ChatGPT 正在使用的模型，用 `--model gpt3` 来使用 gpt3 模型
 5. 加了 `--test` 命令如果大家没付费可以加上这个先看看效果（有 limit 稍微有些慢）
 6. Set the target language like `--language "Simplified Chinese"`. 
    Suppot ` "Japanese" / "Traditional Chinese" / "German" / "French" / "Korean"`.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Make bilingual epub books Using AI translate
 1. pip install -r requirements.txt
 2. OpenAI API key. If you have multiple keys, separate them by commas (xxx,xxx,xxx) to reduce errors caused by API call limits.
 3. A sample book, test_books/animal_farm.epub, is provided for testing purposes.
-4. A sample book, animal_farm.epub, is provided for testing purposes.
+4. The default underlying model is [GPT-3.5-turbo](https://openai.com/blog/introducing-chatgpt-and-whisper-apis) ，which is used by ChatGPT currently. Use `--model gpt3` to change the underlying model to `GPT3`
 5. Use --test command to preview the result if you haven't paid for the service. Note that there is a limit and it may take some time.
-6. Set the target language like `--language "Simplified Chinese"`. 
+6. Set the target language like `--language "Simplified Chinese"`.
    Support ` "Japanese" / "Traditional Chinese" / "German" / "French" / "Korean"`.
    Default target language is `"Simplified Chinese"`. Support language list please see the LANGUAGES at [utils.py](./utils.py).
 7. Use the --proxy parameter to enable users in mainland China to use a proxy when testing locally. Enter a string such as http://127.0.0.1:7890.


### PR DESCRIPTION
依我的理解，ChatGPT 是 OpenAI 开发的聊天机器人，属于一个产品，它正在使用 GPT 3.5 turbo 模型，未来不排除使用其他模型的可能，比如使用 GPT 4 模型。根据官方博客，GPT-3.5-turbo 是一个 OpenAI 的付费模型中更推荐的主流廉价模型，比其他 GPT 3.5 模型便宜了十倍。IMHO，这样修改文档可以更好澄清用户对 billing 疑惑。