### PR TITLE
Improve helper message

### DIFF
--- a/make_book.py
+++ b/make_book.py
@@ -273,7 +273,8 @@ if __name__ == "__main__":
         choices=sorted(LANGUAGES.keys())
         + sorted([k.title() for k in TO_LANGUAGE_CODE.keys()]),
         default="zh-hans",
-        help="language to translate to",
+        metavar="LANGUAGE",
+        help='language to translate to, available: {%(choices)s}'
     )
     parser.add_argument(
         "--resume",


### PR DESCRIPTION
Since too many available languages, use metavar at the first line

### Comparison:

Before
![Screenshot_2023-03-06-20-21-33_1920x1080](https://user-images.githubusercontent.com/19887090/223109077-3d249143-9fa5-43f4-83dc-f9756ebef6f8.png)
 
After
![Screenshot_2023-03-06-20-21-18_1920x1080](https://user-images.githubusercontent.com/19887090/223109136-4efe8ae4-0e70-4528-8450-86d92b3699c7.png)