### PR TITLE
Update Docker command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,23 @@ The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist u
 ## Preparation
 
 1. ChatGPT or OpenAI token
-2. prepared epub books
+2. Prepared epub books
 3. Environment with internet access or proxy
-4. python3.8+
-
+4. Python 3.8+
 
 ## Use
 
 1. pip install -r requirements.txt
 2. OpenAI API key. If you have multiple keys, separate them by commas (xxx,xxx,xxx) to reduce errors caused by API call limits.
 3. A sample book, test_books/animal_farm.epub, is provided for testing purposes.
-4. The default underlying model is [GPT-3.5-turbo](https://openai.com/blog/introducing-chatgpt-and-whisper-apis) ，which is used by ChatGPT currently. Use `--model gpt3` to change the underlying model to `GPT3`
+4. The default underlying model is [GPT-3.5-turbo](https://openai.com/blog/introducing-chatgpt-and-whisper-apis), which is used by ChatGPT currently. Use `--model gpt3` to change the underlying model to `GPT3`
 5. Use --test command to preview the result if you haven't paid for the service. Note that there is a limit and it may take some time.
 6. Set the target language like `--language "Simplified Chinese"`.
    Support ` "Japanese" / "Traditional Chinese" / "German" / "French" / "Korean"`.
    Default target language is `"Simplified Chinese"`. Support language list please see the LANGUAGES at [utils.py](./utils.py).
 7. Use the --proxy parameter to enable users in mainland China to use a proxy when testing locally. Enter a string such as http://127.0.0.1:7890.
 8. Use the --resume command to manually resume the process after an interruption.
-9. If you want to change api_base like using Cloudflare Workers Use --api_base ${url} to support it. **Note: the api url you input should be `https://xxxx/v1', and quotation marks are required. **
+9. If you want to change api_base like using Cloudflare Workers Use --api_base ${url} to support it. **Note: the api url you input should be `https://xxxx/v1', and quotation marks are required.**
 10. Once the translation is complete, a bilingual book named ${book_name}_bilingual.epub will be generated.
 11. If there are any errors or you wish to interrupt the translation using CTRL+C and do not want to continue further, a book named ${book_name}_bilingual_temp.epub will be generated. You can simply rename it to the desired name.
 
@@ -64,18 +63,19 @@ $language=your_language # see utils.py
 
 docker run --rm --name bilingual_book_maker --mount type=bind,source=$folder_path,target='/app/test_books' bilingual_book_maker --book_name "/app/test_books/$book_name" --openai_key $openai_key --no_limit --language $language
 
-# linux
+# Linux
 export folder_path=${your_folder_path}
 export book_name=${your_book_name}
 export openai_key=${your_api_key}
 export language=${your_language}
 
-docker container run --rm --name bilingual_book_maker --mount type=bind,source=${folder_path},target='/app/test_books' bilingual_book_maker --book_name "/app/test_books/${book_name}" --openai_key ${openai_key} --no_limit --language "${language}"
+docker run --rm --name bilingual_book_maker --mount type=bind,source=${folder_path},target='/app/test_books' bilingual_book_maker --book_name "/app/test_books/${book_name}" --openai_key ${openai_key} --no_limit --language "${language}"
 ```
-for example,
+
+e.g.
 ```shell
-# linux
-docker container run --rm --name bilingual_book_maker --mount type=bind,source=/home/user/my_books,target='/app/test_books' bilingual_book_maker --book_name /app/test_books/animal_farm.epub --openai_key sk-XXX --no_limit --test --test_num 1 --language zh-hant
+# Linux
+docker run --rm --name bilingual_book_maker --mount type=bind,source=/home/user/my_books,target='/app/test_books' bilingual_book_maker --book_name /app/test_books/animal_farm.epub --openai_key sk-XXX --no_limit --test --test_num 1 --language zh-hant
 ```
 
 ## Notes


### PR DESCRIPTION
This commit updates the Docker command in the README.md file to remove the container keyword and makes the command more concise. Additionally, it adds an example command and uses the abbreviation e.g. for clarity. No functionality has been changed, only the formatting of the command has been updated.