### PR TITLE
fix(#92): add a arguments to allow NavigableStrings translate

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -28,6 +28,7 @@ bilingual_book_maker 是一个 AI 翻译工具，使用 ChatGPT 帮助用户制�
 9. 如果你遇到了墙需要用 Cloudflare Workers 替换 api_base 请使用 `--api_base ${url}` 来替换。**请注意，此处你输入的api应该是"`https://xxxx/v1`"的字样，域名需要用引号包裹**
 10. 翻译完会生成一本 ${book_name}_bilingual.epub 的双语书
 10. 如果出现了错误或 CTRL + C 中断，不想接下来继续翻译了，会生成一本 ${book_name}_bilingual_temp.epub 的书，直接改成你想要的名字就可以了
+12. 如果你想要翻译电子书中的无标签字符串，可以使用 `--allow_navigable_strings` 参数，会将可遍历字符串加入翻译队列，**注意，在条件允许情况下，请寻找更规范的电子书**
 
 e.g.
 ```shell

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist u
 9. If you want to change api_base like using Cloudflare Workers Use --api_base ${url} to support it. **Note: the api url you input should be `https://xxxx/v1', and quotation marks are required.**
 10. Once the translation is complete, a bilingual book named ${book_name}_bilingual.epub will be generated.
 11. If there are any errors or you wish to interrupt the translation using CTRL+C and do not want to continue further, a book named ${book_name}_bilingual_temp.epub will be generated. You can simply rename it to the desired name.
+12. If you want to translate strings in an e-book that aren't labeled with any tags, you can use the `--allow_navigable_strings` parameter. This will add the strings to the translation queue. **Note that it's best to look for e-books that are more standardized if possible.**
 
 e.g.
 ```shell

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -103,9 +103,16 @@ def main():
         os.environ["http_proxy"] = PROXY
         os.environ["https_proxy"] = PROXY
 
-    OPENAI_API_KEY = options.openai_key or env.get("OPENAI_API_KEY")
-    if not OPENAI_API_KEY:
-        raise Exception("OpenAI API key not provided, please google how to obtain it")
+    translate_model = MODEL_DICT.get(options.model)
+    assert translate_model is not None, "unsupported model"
+    if translate_model in ["gpt3", "chatgptapi"]:
+        OPENAI_API_KEY = options.openai_key or env.get("OPENAI_API_KEY")
+        if not OPENAI_API_KEY:
+            raise Exception(
+                "OpenAI API key not provided, please google how to obtain it"
+            )
+    else:
+        OPENAI_API_KEY = ""
 
     book_type = options.book_name.split(".")[-1]
     support_type_list = list(BOOK_LOADER_DICT.keys())
@@ -113,8 +120,6 @@ def main():
         raise Exception(
             f"now only support files of these formats: {','.join(support_type_list)}"
         )
-    translate_model = MODEL_DICT.get(options.model)
-    assert translate_model is not None, "unsupported model"
 
     book_loader = BOOK_LOADER_DICT.get(book_type)
     assert book_loader is not None, "unsupported loader"

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -89,6 +89,13 @@ def main():
         default="p",
         help="example --translate-tags p,blockquote",
     )
+    parser.add_argument(
+        "--allow_navigable_strings",
+        dest="allow_navigable_strings",
+        action="store_true",
+        default=False,
+        help="allow NavigableStrings to be translated",
+    )
 
     options = parser.parse_args()
     PROXY = options.proxy
@@ -129,6 +136,7 @@ def main():
         is_test=options.test,
         test_num=options.test_num,
         translate_tags=options.translate_tags,
+        allow_navigable_strings=options.allow_navigable_strings,
     )
     e.make_bilingual_book()
 

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -80,7 +80,9 @@ class EPUBBookLoader(BaseBookLoader):
             for i in all_items
         )
         all_p_length += self.allow_navigable_strings * sum(
-            0 if i.get_type() != ITEM_DOCUMENT else len(bs(i.content, "html.parser").findAll(text=True))
+            0
+            if i.get_type() != ITEM_DOCUMENT
+            else len(bs(i.content, "html.parser").findAll(text=True))
             for i in all_items
         )
         pbar = tqdm(total=self.test_num) if self.is_test else tqdm(total=all_p_length)


### PR DESCRIPTION
没有标签包裹的字符串无法被翻译，此处提供了一个参数可供选择。但是这类epub猜测可能导致排版出现问题，建议实在需要再加入

Strings that are not wrapped in tags cannot be translated, but a parameter is provided here as an option. However, allowing untagged strings in EPUB files may lead to formatting issues. Therefore, it is recommended to use this option only when necessary.