### PR TITLE
support --translation_style

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist u
 - `--accumulated_num` Wait for how many tokens have been accumulated before starting the translation. gpt3.5 limits the total_token to 4090. For example, if you use --accumulated_num 1600, maybe openai will
 output 2200 tokens and maybe 200 tokens for other messages in the system messages user messages, 1600+2200+200=4000, So you are close to reaching the limit. You have to choose your own
 value, there is no way to know if the limit is reached before sending
+- `--translation_style` example: `--translation_style "color: #808080; font-style: italic;"`
 
 ### Examples
 

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -183,6 +183,13 @@ So you are close to reaching the limit. You have to choose your own value, there
 """,
     )
     parser.add_argument(
+        "--translation_style",
+        dest="translation_style",
+        type=str,
+        default="",
+        help="""ex: --translation_style "color: #808080; font-style: italic;" """,
+    )
+    parser.add_argument(
         "--batch_size",
         dest="batch_size",
         type=int,
@@ -268,6 +275,8 @@ So you are close to reaching the limit. You have to choose your own value, there
         e.translate_tags = options.translate_tags
     if options.accumulated_num > 1:
         e.accumulated_num = options.accumulated_num
+    if options.translation_style != "":
+        e.translation_style = options.translation_style
     if options.batch_size:
         e.batch_size = options.batch_size
     e.make_bilingual_book()

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -186,7 +186,6 @@ So you are close to reaching the limit. You have to choose your own value, there
         "--translation_style",
         dest="translation_style",
         type=str,
-        default="",
         help="""ex: --translation_style "color: #808080; font-style: italic;" """,
     )
     parser.add_argument(
@@ -275,7 +274,7 @@ So you are close to reaching the limit. You have to choose your own value, there
         e.translate_tags = options.translate_tags
     if options.accumulated_num > 1:
         e.accumulated_num = options.accumulated_num
-    if options.translation_style != "":
+    if options.translation_style:
         e.translation_style = options.translation_style
     if options.batch_size:
         e.batch_size = options.batch_size

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -123,7 +123,7 @@ class EPUBBookLoader(BaseBookLoader):
                 new_p.string = self.translate_model.translate(p.text)
                 self.p_to_save.append(new_p.text)
 
-        self.helper.insert_with_style(p, new_p.string, self.translation_style)
+        self.helper.insert_trans(p, new_p.string, self.translation_style)
         index += 1
 
         if index % 20 == 0:
@@ -275,7 +275,7 @@ class EPUBBookLoader(BaseBookLoader):
                                 new_p = self.p_to_save[index]
                             else:
                                 new_p.string = self.p_to_save[index]
-                            self.helper.insert_with_style(
+                            self.helper.insert_trans(
                                 p, new_p.string, self.translation_style
                             )
                             index += 1

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -50,7 +50,10 @@ class EPUBBookLoader(BaseBookLoader):
         self.translate_tags = "p"
         self.allow_navigable_strings = False
         self.accumulated_num = 1
-        self.helper = EPUBBookLoaderHelper(self.translate_model, self.accumulated_num)
+        self.translation_style = ""
+        self.helper = EPUBBookLoaderHelper(
+            self.translate_model, self.accumulated_num, self.translation_style
+        )
 
         # monkey pathch for # 173
         def _write_items_patch(obj):
@@ -127,7 +130,7 @@ class EPUBBookLoader(BaseBookLoader):
                 new_p.string = self.translate_model.translate(p.text)
                 self.p_to_save.append(new_p.text)
 
-        p.insert_after(new_p)
+        self.helper.insert_with_style(p, new_p.string, self.translation_style)
         index += 1
 
         if index % 20 == 0:
@@ -180,6 +183,9 @@ class EPUBBookLoader(BaseBookLoader):
                 count = length
 
     def make_bilingual_book(self):
+        self.helper = EPUBBookLoaderHelper(
+            self.translate_model, self.accumulated_num, self.translation_style
+        )
         new_book = self._make_new_book(self.origin_book)
         all_items = list(self.origin_book.get_items())
         trans_taglist = self.translate_tags.split(",")
@@ -283,7 +289,9 @@ class EPUBBookLoader(BaseBookLoader):
                                 new_p = self.p_to_save[index]
                             else:
                                 new_p.string = self.p_to_save[index]
-                            p.insert_after(new_p)
+                            self.helper.insert_with_style(
+                                p, new_p.string, self.translation_style
+                            )
                             index += 1
                         else:
                             break

--- a/book_maker/loader/helper.py
+++ b/book_maker/loader/helper.py
@@ -3,15 +3,25 @@ from copy import copy
 
 
 class EPUBBookLoaderHelper:
-    def __init__(self, translate_model, accumulated_num):
+    def __init__(self, translate_model, accumulated_num, translation_style):
         self.translate_model = translate_model
         self.accumulated_num = accumulated_num
+        self.translation_style = translation_style
+
+    def insert_with_style(self, p, text, translation_style=""):
+        if p.string is not None and p.string.strip() == text.strip():
+            return
+        new_p = copy(p)
+        new_p.string = text
+        if translation_style != "":
+            new_p["style"] = translation_style
+        p.insert_after(new_p)
 
     def deal_new(self, p, wait_p_list):
         self.deal_old(wait_p_list)
-        new_p = copy(p)
-        new_p.string = self.translate_model.translate(p.text)
-        p.insert_after(new_p)
+        self.insert_with_style(
+            p, self.translate_model.translate(p.text), self.translation_style
+        )
 
     def deal_old(self, wait_p_list):
         if not wait_p_list:
@@ -22,9 +32,7 @@ class EPUBBookLoaderHelper:
         for i in range(len(wait_p_list)):
             if i < len(result_txt_list):
                 p = wait_p_list[i]
-                new_p = copy(p)
-                new_p.string = result_txt_list[i]
-                p.insert_after(new_p)
+                self.insert_with_style(p, result_txt_list[i], self.translation_style)
 
         wait_p_list.clear()
 

--- a/book_maker/loader/helper.py
+++ b/book_maker/loader/helper.py
@@ -8,7 +8,7 @@ class EPUBBookLoaderHelper:
         self.accumulated_num = accumulated_num
         self.translation_style = translation_style
 
-    def insert_with_style(self, p, text, translation_style=""):
+    def insert_trans(self, p, text, translation_style=""):
         if p.string is not None and p.string.strip() == text.strip():
             return
         new_p = copy(p)
@@ -19,7 +19,7 @@ class EPUBBookLoaderHelper:
 
     def deal_new(self, p, wait_p_list):
         self.deal_old(wait_p_list)
-        self.insert_with_style(
+        self.insert_trans(
             p, self.translate_model.translate(p.text), self.translation_style
         )
 
@@ -32,7 +32,7 @@ class EPUBBookLoaderHelper:
         for i in range(len(wait_p_list)):
             if i < len(result_txt_list):
                 p = wait_p_list[i]
-                self.insert_with_style(p, result_txt_list[i], self.translation_style)
+                self.insert_trans(p, result_txt_list[i], self.translation_style)
 
         wait_p_list.clear()
 


### PR DESCRIPTION
I feel it looks more comfortable to specify the translated style, hope to support this option , ex:
` --translation_style "color: #808080; font-style: italic;"`

` --translation_style "color: #4a4a4a; font-style: normal; background-color: #f7f7f7; padding: 5px; margin: 10px 0; border-radius: 5px;"`

![style2](https://user-images.githubusercontent.com/89069008/226104545-7c029bb1-5325-46d4-a1eb-ec4e7bbaee97.png)