### PR TITLE
support --retranslate

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist u
 output 2200 tokens and maybe 200 tokens for other messages in the system messages user messages, 1600+2200+200=4000, So you are close to reaching the limit. You have to choose your own
 value, there is no way to know if the limit is reached before sending
 - `--translation_style` example: `--translation_style "color: #808080; font-style: italic;"`
+- `--retranslate` `--retranslate "translated book" "filename_in_epub,start(optional),end(optional)"`
+Retranslate the entire file: `--book_name "test_books/animal_farm.epub" --retranslate "test_books/animal_farm_bilingual.epub" "index_split_000.html"`
+Retranslate the matched 1-2 tags: `--book_name "test_books/animal_farm.epub" --retranslate "test_books/animal_farm_bilingual.epub" "index_split_000.html,1,2"`
 
 ### Examples
 

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -194,6 +194,16 @@ So you are close to reaching the limit. You have to choose your own value, there
         type=int,
         help="how many lines will be translated by aggregated translation(This options currently only applies to txt files)",
     )
+    parser.add_argument(
+        "--retranslate",
+        dest="retranslate",
+        nargs=2,
+        type=str,
+        help="""--retranslate "translated book" "filename_in_epub,start(optional),end(optional)"
+Retranslate the entire file: --book_name "test_books/animal_farm.epub" --retranslate "test_books/animal_farm_bilingual.epub" "index_split_000.html"
+Retranslate the matched 1-2 tags: --book_name "test_books/animal_farm.epub" --retranslate "test_books/animal_farm_bilingual.epub" "index_split_000.html,1,2"
+""",
+    )
 
     options = parser.parse_args()
 
@@ -283,6 +293,9 @@ So you are close to reaching the limit. You have to choose your own value, there
         e.translation_style = options.translation_style
     if options.batch_size:
         e.batch_size = options.batch_size
+    if options.retranslate:
+        e.retranslate = options.retranslate
+
     e.make_bilingual_book()
 
 


### PR DESCRIPTION
If a file in epub is not translated well, it is supported to re-translate it separately, and you can also translate some consecutive tags in it, generate `name_fix.epub`

Retranslate the index_split_000.html: `--book_name "test_books/animal_farm.epub" --retranslate "test_books/animal_farm_bilingual.epub" "index_split_000.html"`
Retranslate the matched 1-2 tags in index_split_000.html: `--book_name "test_books/animal_farm.epub" --retranslate "test_books/animal_farm_bilingual.epub" "index_split_000.html,1,2"`