### PR TITLE
support exclude or only translate filelist, exclude taglist

### DIFF
--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -174,6 +174,13 @@ def main():
         help="example --translate-tags p,blockquote",
     )
     parser.add_argument(
+        "--exclude_translate-tags",
+        dest="exclude_translate_tags",
+        type=str,
+        default="sup",
+        help="example --exclude_translate-tags table,sup",
+    )
+    parser.add_argument(
         "--allow_navigable_strings",
         dest="allow_navigable_strings",
         action="store_true",
@@ -329,6 +336,8 @@ So you are close to reaching the limit. You have to choose your own value, there
         e.allow_navigable_strings = True
     if options.translate_tags:
         e.translate_tags = options.translate_tags
+    if options.exclude_translate_tags:
+        e.exclude_translate_tags = options.exclude_translate_tags
     if options.exclude_filelist:
         e.exclude_filelist = options.exclude_filelist
     if options.only_filelist:

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -153,6 +153,20 @@ def main():
         help="specify base url other than the OpenAI's official API address",
     )
     parser.add_argument(
+        "--exclude_filelist",
+        dest="exclude_filelist",
+        type=str,
+        default="",
+        help="if you have more than one file to exclude, please use comma to split them, example: --exclude_filelist 'nav.xhtml,cover.xhtml'",
+    )
+    parser.add_argument(
+        "--only_filelist",
+        dest="only_filelist",
+        type=str,
+        default="",
+        help="if you only have a few files with translations, please use comma to split them, example: --only_filelist 'nav.xhtml,cover.xhtml'",
+    )
+    parser.add_argument(
         "--translate-tags",
         dest="translate_tags",
         type=str,
@@ -315,6 +329,10 @@ So you are close to reaching the limit. You have to choose your own value, there
         e.allow_navigable_strings = True
     if options.translate_tags:
         e.translate_tags = options.translate_tags
+    if options.exclude_filelist:
+        e.exclude_filelist = options.exclude_filelist
+    if options.only_filelist:
+        e.only_filelist = options.only_filelist
     if options.accumulated_num > 1:
         e.accumulated_num = options.accumulated_num
     if options.translation_style:

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -45,6 +45,7 @@ class EPUBBookLoader(BaseBookLoader):
         self.is_test = is_test
         self.test_num = test_num
         self.translate_tags = "p"
+        self.exclude_translate_tags = "sup"
         self.allow_navigable_strings = False
         self.accumulated_num = 1
         self.translation_style = ""
@@ -120,14 +121,18 @@ class EPUBBookLoader(BaseBookLoader):
 
         new_p = copy(p)
 
+        for p_exclude in self.exclude_translate_tags.split(","):
+            for pt in new_p.find_all(p_exclude):
+                pt.extract()
+
         if self.resume and index < p_to_save_len:
             new_p.string = self.p_to_save[index]
         else:
             if type(p) == NavigableString:
-                new_p = self.translate_model.translate(p.text)
+                new_p = self.translate_model.translate(new_p.text)
                 self.p_to_save.append(new_p)
             else:
-                new_p.string = self.translate_model.translate(p.text)
+                new_p.string = self.translate_model.translate(new_p.text)
                 self.p_to_save.append(new_p.text)
 
         self.helper.insert_trans(p, new_p.string, self.translation_style)
@@ -144,8 +149,11 @@ class EPUBBookLoader(BaseBookLoader):
         for i in range(len(p_list)):
             p = p_list[i]
             temp_p = copy(p)
-            for sup in temp_p.find_all("sup"):
-                sup.extract()
+
+            for p_exclude in self.exclude_translate_tags.split(","):
+                for pt in temp_p.find_all(p_exclude):
+                    pt.extract()
+
             if any(
                 [not p.text, self._is_special_text(temp_p.text), not_trans(temp_p.text)]
             ):

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -314,6 +314,16 @@ class EPUBBookLoader(BaseBookLoader):
         fixstart=None,
         fixend=None,
     ):
+        if self.only_filelist != "" and not item.file_name in self.only_filelist.split(
+            ","
+        ):
+            return index
+        elif self.only_filelist == "" and item.file_name in self.exclude_filelist.split(
+            ","
+        ):
+            new_book.add_item(item)
+            return index
+
         if not os.path.exists("log"):
             os.makedirs("log")
 
@@ -399,16 +409,6 @@ class EPUBBookLoader(BaseBookLoader):
                     new_book.add_item(item)
 
             for item in self.origin_book.get_items_of_type(ITEM_DOCUMENT):
-                if (
-                    self.only_filelist != ""
-                    and not item.file_name in self.only_filelist.split(",")
-                ):
-                    continue
-                elif (
-                    self.only_filelist == ""
-                    and item.file_name in self.exclude_filelist.split(",")
-                ):
-                    continue
                 index = self.process_item(
                     item, index, p_to_save_len, pbar, new_book, trans_taglist
                 )

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -52,6 +52,8 @@ class EPUBBookLoader(BaseBookLoader):
             self.translate_model, self.accumulated_num, self.translation_style
         )
         self.retranslate = None
+        self.exclude_filelist = ""
+        self.only_filelist = ""
 
         # monkey patch for # 173
         def _write_items_patch(obj):
@@ -389,8 +391,16 @@ class EPUBBookLoader(BaseBookLoader):
                     new_book.add_item(item)
 
             for item in self.origin_book.get_items_of_type(ITEM_DOCUMENT):
-                # if item.file_name != "OEBPS/ch01.xhtml":
-                #     continue
+                if (
+                    self.only_filelist != ""
+                    and not item.file_name in self.only_filelist.split(",")
+                ):
+                    continue
+                elif (
+                    self.only_filelist == ""
+                    and item.file_name in self.exclude_filelist.split(",")
+                ):
+                    continue
                 index = self.process_item(
                     item, index, p_to_save_len, pbar, new_book, trans_taglist
                 )


### PR DESCRIPTION
if you only have a few files with translations, please use comma to split them, example: `--only_filelist 'nav.xhtml,cover.xhtml'`

if you have more than one file to exclude, please use comma to split them, example: `--exclude_filelist 'nav.xhtml,cover.xhtml'`

if you have more than one tag to exclude, please use comma to split them, example: `--exclude_filelist 'table,sup'`

related issue: https://github.com/yihong0618/bilingual_book_maker/issues/210 https://github.com/yihong0618/bilingual_book_maker/issues/191