### PR TITLE
MakeFile easy to test local

### DIFF
--- a/.github/workflows/make_test_ebook.yaml
+++ b/.github/workflows/make_test_ebook.yaml
@@ -34,42 +34,8 @@ jobs:
         run: |
             pip install .
 
-      - name: make normal ebook test using google translate and cli
+      - name: Run tests
         run: |
-            bbook_maker --book_name "test_books/Liber_Esther.epub" --test --test_num 10 --model google --translate-tags div,p
-            bbook_maker --book_name "test_books/Liber_Esther.epub" --test --test_num 20 --model google
-
-      - name: make txt book test using google translate
-        run: |
-          python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --test_num 20 --model google
-
-      - name: make txt book test with batch_size
-        run: |
-          python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --batch_size 30 --test_num 20 --model google
-  
-      - name: make caiyun translator test
-        if: env.BBM_CAIYUN_API_KEY != null
-        run: |
-          python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --batch_size 30 --test_num 100 --model caiyun
-
-      - name: make deepl translator test
-        if: env.BBM_CAIYUN_API_KEY != null
-        run: |
-          python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --batch_size 30 --test_num 20 --model deepl
-          python3 make_book.py --book_name test_books/Lex_Fridman_episode_322.srt --test 
-
-      - name: make openai key ebook test
-        if: env.BBM_DEEPL_API_KEY != null
-        run: |
-            python3 make_book.py --book_name "test_books/lemo.epub" --test --test_num 5 --language zh-hans
-            python3 make_book.py --book_name "test_books/animal_farm.epub" --test --test_num 5 --language ja --model gpt3 --prompt prompt_template_sample.txt
-            python3 make_book.py --book_name "test_books/animal_farm.epub" --test --test_num 5 --language ja --prompt prompt_template_sample.json
-            python3 make_book.py --book_name test_books/Lex_Fridman_episode_322.srt --test --test_num 20
-            
-      - name: Rename and Upload ePub
-        if: env.OPENAI_API_KEY != null
-        uses: actions/upload-artifact@v2
-        with:
-          name: epub_output
-          path: "test_books/lemo_bilingual.epub"
+            pip install pytest
+            pytest tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+SHELL := /bin/bash
+
+fmt:
+	@echo "Running formatter ..."
+	venv/bin/black .
+
+.PHONY:tests
+tests:
+	@echo "Running tests ..."
+	venv/bin/pytest tests/test_integration.py

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 from setuptools import find_packages, setup
 
+
+def get_required_packges():
+    packages = []
+    with open("requirements.txt") as filep:
+        for line in filep:
+            packages.append(line.rstrip())
+
+    return packages
+
+
 setup(
     name="bbook_maker",
     description="The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist users in creating multi-language versions of epub/txt files and books.",
@@ -11,15 +21,7 @@ setup(
     packages=find_packages(),
     url="https://github.com/yihong0618/bilingual_book_maker",
     python_requires=">=3.7",
-    install_requires=[
-        "bs4",
-        "openai",
-        "requests",
-        "ebooklib",
-        "rich",
-        "tqdm",
-        "tiktoken",
-    ],
+    install_requires=get_required_packges(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,301 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def test_book_dir() -> str:
+    """Return test book dir"""
+    # TODO: Can move this to conftest.py if there will be more unittests
+    return str(Path(__file__).parent.parent / "test_books")
+
+
+def test_google_translate_epub(test_book_dir, tmpdir):
+    """Test google translate epub"""
+    shutil.copyfile(
+        os.path.join(test_book_dir, "Liber_Esther.epub"),
+        os.path.join(tmpdir, "Liber_Esther.epub"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "Liber_Esther.epub"),
+            "--test",
+            "--test_num",
+            "20",
+            "--model",
+            "google",
+        ]
+    )
+
+    assert os.path.isfile(os.path.join(tmpdir, "Liber_Esther_bilingual.epub"))
+    assert os.path.getsize(os.path.join(tmpdir, "Liber_Esther_bilingual.epub")) != 0
+
+
+def test_google_translate_epub_cli():
+    pass
+
+
+def test_google_translate_txt(test_book_dir, tmpdir):
+    """Test google translate txt"""
+    shutil.copyfile(
+        os.path.join(test_book_dir, "the_little_prince.txt"),
+        os.path.join(tmpdir, "the_little_prince.txt"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "the_little_prince.txt"),
+            "--test",
+            "--test_num",
+            "20",
+            "--model",
+            "google",
+        ]
+    )
+    assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
+    assert os.path.getsize(os.path.join(tmpdir, "the_little_prince_bilingual.txt")) != 0
+
+
+def test_google_translate_txt_batch_size(test_book_dir, tmpdir):
+    """Test google translate txt with batch_size"""
+    shutil.copyfile(
+        os.path.join(test_book_dir, "the_little_prince.txt"),
+        os.path.join(tmpdir, "the_little_prince.txt"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "the_little_prince.txt"),
+            "--test",
+            "--batch_size",
+            "30",
+            "--test_num",
+            "20",
+            "--model",
+            "google",
+        ]
+    )
+
+    assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
+    assert os.path.getsize(os.path.join(tmpdir, "the_little_prince_bilingual.txt")) != 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("BBM_CAIYUN_API_KEY") is None,
+    reason="No BBM_CAIYUN_API_KEY in environment variable.",
+)
+def test_caiyun_translate_txt(test_book_dir, tmpdir):
+    """Test caiyun tranlate txt"""
+    shutil.copyfile(
+        os.path.join(test_book_dir, "the_little_prince.txt"),
+        os.path.join(tmpdir, "the_little_prince.txt"),
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "the_little_prince.txt"),
+            "--test",
+            "--batch_size",
+            "30",
+            "--test_num",
+            "100",
+            "--model",
+            "caiyun",
+        ]
+    )
+
+    assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
+    assert os.path.getsize(os.path.join(tmpdir, "the_little_prince_bilingual.txt")) != 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("BBM_DEEPL_API_KEY") is None,
+    reason="No BBM_DEEPL_API_KEY in environment variable.",
+)
+def test_deepl_translate_txt(test_book_dir, tmpdir):
+    shutil.copyfile(
+        os.path.join(test_book_dir, "the_little_prince.txt"),
+        os.path.join(tmpdir, "the_little_prince.txt"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "the_little_prince.txt"),
+            "--test",
+            "--batch_size",
+            "30",
+            "--test_num",
+            "20",
+            "--model",
+            "deepl",
+        ]
+    )
+
+    assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
+    assert os.path.getsize(os.path.join(tmpdir, "the_little_prince_bilingual.txt")) != 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("BBM_DEEPL_API_KEY") is None,
+    reason="No BBM_DEEPL_API_KEY in environment variable.",
+)
+def test_deepl_translate_srt(test_book_dir, tmpdir):
+    shutil.copyfile(
+        os.path.join(test_book_dir, "Lex_Fridman_episode_322.srt"),
+        os.path.join(tmpdir, "Lex_Fridman_episode_322.srt"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "Lex_Fridman_episode_322.srt"),
+            "--test",
+            "--batch_size",
+            "30",
+            "--test_num",
+            "20",
+            "--model",
+            "deepl",
+        ]
+    )
+
+    assert os.path.isfile(os.path.join(tmpdir, "Lex_Fridman_episode_322_bilingual.srt"))
+    assert (
+        os.path.getsize(os.path.join(tmpdir, "Lex_Fridman_episode_322_bilingual.srt"))
+        != 0
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("OPENAI_API_KEY") is None,
+    reason="No OPENAI_API_KEY in environment variable.",
+)
+def test_openai_translate_epub_zh_hans(test_book_dir, tmpdir):
+    shutil.copyfile(
+        os.path.join(test_book_dir, "lemo.epub"),
+        os.path.join(tmpdir, "lemo.epub"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "lemo.epub"),
+            "--test",
+            "--test_num",
+            "5",
+            "--language zh-hans",
+        ]
+    )
+    assert os.path.isfile(os.path.join(tmpdir, "lemo_bilingual.epub"))
+    assert os.path.getsize(os.path.join(tmpdir, "lemo_bilingual.epub")) != 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("OPENAI_API_KEY") is None,
+    reason="No OPENAI_API_KEY in environment variable.",
+)
+def test_openai_translate_epub_ja_prompt_txt(test_book_dir, tmpdir):
+    shutil.copyfile(
+        os.path.join(test_book_dir, "animal_farm.epub"),
+        os.path.join(tmpdir, "animal_farm.epub"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "animal_farm.epub"),
+            "--test",
+            "--test_num",
+            "5",
+            "--language",
+            "ja",
+            "--model",
+            "gpt3",
+            "--prompt",
+            "prompt_template_sample.txt",
+        ]
+    )
+    assert os.path.isfile(os.path.join(tmpdir, "animal_farm_bilingual.epub"))
+    assert os.path.getsize(os.path.join(tmpdir, "animal_farm_bilingual.epub")) != 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("OPENAI_API_KEY") is None,
+    reason="No OPENAI_API_KEY in environment variable.",
+)
+def test_openai_translate_epub_ja_prompt_json(test_book_dir, tmpdir):
+    shutil.copyfile(
+        os.path.join(test_book_dir, "animal_farm.epub"),
+        os.path.join(tmpdir, "animal_farm.epub"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join(tmpdir, "animal_farm.epub"),
+            "--test",
+            "--test_num",
+            "5",
+            "--language",
+            "ja",
+            "--prompt",
+            "prompt_template_sample.json",
+        ]
+    )
+    assert os.path.isfile(os.path.join(tmpdir, "animal_farm_bilingual.epub"))
+    assert os.path.getsize(os.path.join(tmpdir, "animal_farm_bilingual.epub")) != 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("OPENAI_API_KEY") is None,
+    reason="No OPENAI_API_KEY in environment variable.",
+)
+def test_openai_translate_srt(test_book_dir, tmpdir):
+    shutil.copyfile(
+        os.path.join(test_book_dir, "Lex_Fridman_episode_322.srt"),
+        os.path.join(tmpdir, "Lex_Fridman_episode_322.srt"),
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "make_book.py",
+            "--book_name",
+            os.path.join("Lex_Fridman_episode_322.srt"),
+            "--test",
+            "--test_num",
+            "20",
+        ]
+    )
+    assert os.path.isfile(os.path.join(tmpdir, "Lex_Fridman_episode_322_bilingual.srt"))
+    assert (
+        os.path.getsize(os.path.join(tmpdir, "Lex_Fridman_episode_322_bilingual.srt"))
+        != 0
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,7 +32,8 @@ def test_google_translate_epub(test_book_dir, tmpdir):
             "20",
             "--model",
             "google",
-        ]
+        ],
+        env=os.environ.copy(),
     )
 
     assert os.path.isfile(os.path.join(tmpdir, "Liber_Esther_bilingual.epub"))
@@ -61,7 +62,8 @@ def test_google_translate_txt(test_book_dir, tmpdir):
             "20",
             "--model",
             "google",
-        ]
+        ],
+        env=os.environ.copy(),
     )
     assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
     assert os.path.getsize(os.path.join(tmpdir, "the_little_prince_bilingual.txt")) != 0
@@ -87,7 +89,8 @@ def test_google_translate_txt_batch_size(test_book_dir, tmpdir):
             "20",
             "--model",
             "google",
-        ]
+        ],
+        env=os.environ.copy(),
     )
 
     assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
@@ -117,7 +120,8 @@ def test_caiyun_translate_txt(test_book_dir, tmpdir):
             "100",
             "--model",
             "caiyun",
-        ]
+        ],
+        env=os.environ.copy(),
     )
 
     assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
@@ -147,7 +151,8 @@ def test_deepl_translate_txt(test_book_dir, tmpdir):
             "20",
             "--model",
             "deepl",
-        ]
+        ],
+        env=os.environ.copy(),
     )
 
     assert os.path.isfile(os.path.join(tmpdir, "the_little_prince_bilingual.txt"))
@@ -177,7 +182,8 @@ def test_deepl_translate_srt(test_book_dir, tmpdir):
             "20",
             "--model",
             "deepl",
-        ]
+        ],
+        env=os.environ.copy(),
     )
 
     assert os.path.isfile(os.path.join(tmpdir, "Lex_Fridman_episode_322_bilingual.srt"))
@@ -207,7 +213,8 @@ def test_openai_translate_epub_zh_hans(test_book_dir, tmpdir):
             "--test_num",
             "5",
             "--language zh-hans",
-        ]
+        ],
+        env=os.environ.copy(),
     )
     assert os.path.isfile(os.path.join(tmpdir, "lemo_bilingual.epub"))
     assert os.path.getsize(os.path.join(tmpdir, "lemo_bilingual.epub")) != 0
@@ -238,7 +245,8 @@ def test_openai_translate_epub_ja_prompt_txt(test_book_dir, tmpdir):
             "gpt3",
             "--prompt",
             "prompt_template_sample.txt",
-        ]
+        ],
+        env=os.environ.copy(),
     )
     assert os.path.isfile(os.path.join(tmpdir, "animal_farm_bilingual.epub"))
     assert os.path.getsize(os.path.join(tmpdir, "animal_farm_bilingual.epub")) != 0
@@ -267,7 +275,8 @@ def test_openai_translate_epub_ja_prompt_json(test_book_dir, tmpdir):
             "ja",
             "--prompt",
             "prompt_template_sample.json",
-        ]
+        ],
+        env=os.environ.copy(),
     )
     assert os.path.isfile(os.path.join(tmpdir, "animal_farm_bilingual.epub"))
     assert os.path.getsize(os.path.join(tmpdir, "animal_farm_bilingual.epub")) != 0
@@ -292,7 +301,8 @@ def test_openai_translate_srt(test_book_dir, tmpdir):
             "--test",
             "--test_num",
             "20",
-        ]
+        ],
+        env=os.environ.copy(),
     )
     assert os.path.isfile(os.path.join(tmpdir, "Lex_Fridman_episode_322_bilingual.srt"))
     assert (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -98,7 +98,7 @@ def test_google_translate_txt_batch_size(test_book_dir, tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("BBM_CAIYUN_API_KEY") is None,
+    not os.environ.get("BBM_CAIYUN_API_KEY"),
     reason="No BBM_CAIYUN_API_KEY in environment variable.",
 )
 def test_caiyun_translate_txt(test_book_dir, tmpdir):
@@ -129,7 +129,7 @@ def test_caiyun_translate_txt(test_book_dir, tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("BBM_DEEPL_API_KEY") is None,
+    not os.environ.get("BBM_DEEPL_API_KEY"),
     reason="No BBM_DEEPL_API_KEY in environment variable.",
 )
 def test_deepl_translate_txt(test_book_dir, tmpdir):
@@ -160,7 +160,7 @@ def test_deepl_translate_txt(test_book_dir, tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("BBM_DEEPL_API_KEY") is None,
+    not os.environ.get("BBM_DEEPL_API_KEY"),
     reason="No BBM_DEEPL_API_KEY in environment variable.",
 )
 def test_deepl_translate_srt(test_book_dir, tmpdir):
@@ -194,7 +194,7 @@ def test_deepl_translate_srt(test_book_dir, tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("OPENAI_API_KEY") is None,
+    not os.environ.get("OPENAI_API_KEY"),
     reason="No OPENAI_API_KEY in environment variable.",
 )
 def test_openai_translate_epub_zh_hans(test_book_dir, tmpdir):
@@ -212,7 +212,8 @@ def test_openai_translate_epub_zh_hans(test_book_dir, tmpdir):
             "--test",
             "--test_num",
             "5",
-            "--language zh-hans",
+            "--language",
+            "zh-hans",
         ],
         env=os.environ.copy(),
     )
@@ -221,7 +222,7 @@ def test_openai_translate_epub_zh_hans(test_book_dir, tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("OPENAI_API_KEY") is None,
+    not os.environ.get("OPENAI_API_KEY"),
     reason="No OPENAI_API_KEY in environment variable.",
 )
 def test_openai_translate_epub_ja_prompt_txt(test_book_dir, tmpdir):
@@ -253,7 +254,7 @@ def test_openai_translate_epub_ja_prompt_txt(test_book_dir, tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("OPENAI_API_KEY") is None,
+    not os.environ.get("OPENAI_API_KEY"),
     reason="No OPENAI_API_KEY in environment variable.",
 )
 def test_openai_translate_epub_ja_prompt_json(test_book_dir, tmpdir):
@@ -283,7 +284,7 @@ def test_openai_translate_epub_ja_prompt_json(test_book_dir, tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("OPENAI_API_KEY") is None,
+    not os.environ.get("OPENAI_API_KEY"),
     reason="No OPENAI_API_KEY in environment variable.",
 )
 def test_openai_translate_srt(test_book_dir, tmpdir):


### PR DESCRIPTION
#192
 
# Change
1. refactor the test flow into unittests
2. add a Makefile for local test
Since I don't have api permission, @yihong0618 could you help me test the Makefile?

# Need to discuss
I notice that the packages in requirements.txt and install_requires are not consistent, so I add a fix here. If @yihong0618 you are intend to let this happen, I can delete the fix.

# Future enhancement
1. Add linter like pylint or flake in both Makefile and github workflow
https://github.com/yihong0618/bilingual_book_maker/blob/45bfdf7907518b0579313560af80323e7f1e9b55/book_maker/obok.py#L264
I noticed that this package imported in source code but not listed in requirements.txt. Add linter may avoid this bug.
 
2. Break the github workflow
github workflow can break into "linter" and "tests".
"linter" can include isort, black, autoflake, which can directly format the codes and commit.
"tests" can run tests.