### PR TITLE
Google Translate skipping paragraphs

### DIFF
--- a/book_maker/translator/google_translator.py
+++ b/book_maker/translator/google_translator.py
@@ -27,7 +27,7 @@ class Google(Base):
 
     def translate(self, text):
         print(text)
-        r = self.session.post(
+        """r = self.session.post(
             self.api_url,
             headers=self.headers,
             data=f"q={requests.utils.quote(text)}",
@@ -36,6 +36,24 @@ class Google(Base):
             return text
         t_text = "".join(
             [sentence.get("trans", "") for sentence in r.json()["sentences"]],
-        )
+        )"""
+        t_text = self._retry_translate(text)
         print("[bold green]" + re.sub("\n{3,}", "\n\n", t_text) + "[/bold green]")
         return t_text
+
+    def _retry_translate(self, text, timeout=3):
+        time = 0
+        while time <= timeout:
+            time += 1
+            r = self.session.post(
+                self.api_url,
+                headers=self.headers,
+                data=f"q={requests.utils.quote(text)}",
+                timeout=3,
+            )
+            if r.ok:
+                t_text = "".join(
+                    [sentence.get("trans", "") for sentence in r.json()["sentences"]],
+                )
+                return t_text
+        return text


### PR DESCRIPTION
Improved the issue of Google Translate skipping paragraphs due to network problems by increasing the number of attempts (defaulting to 3 attempts).