### PR TITLE
fix(dockerfile): bug fix for building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY requirements.txt setup.py .
 
 RUN pip install -r /app/requirements.txt
 


### PR DESCRIPTION
Dockerfile中复制了requirements.txt，但文件的内容是`-e .`，需要同时复制setup.py才能正常构建镜像。