### PR TITLE
Github actions for deploy doc page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,4 +13,4 @@ jobs:
         with:
           python-version: '3.9'
       - run: pip install mkdocs mkdocs-material
-      - run: mkdocs gh-deploy --force --clean --verbose
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,20 +1,16 @@
-name: Publish docs via GitHub Pages
+name: Publish docs
 on:
   push:
     branches:
       - main
 
 jobs:
-  build:
-    name: Deploy docs
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v2
-
-      - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONFIG_FILE: mkdocs.yml
-          REQUIREMENTS: requirements.txt
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - run: pip install mkdocs mkdocs-material
+      - run: mkdocs gh-deploy --force --clean --verbose


### PR DESCRIPTION
This action generate a branch called "gh-pages". Everytime when a new pull request is merged to main, this branch will auto-update and publish latest documentation.

This works in my forked repo. https://yylizh.github.io/bilingual_book_maker/
ref: https://github.com/yihong0618/bilingual_book_maker/pull/319

