### PR TITLE
fix: bugs for using exlude_filelists and only_filelists

### DIFF
--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -403,13 +403,37 @@ class EPUBBookLoader(BaseBookLoader):
         trans_taglist = self.translate_tags.split(",")
         all_p_length = sum(
             0
-            if i.get_type() != ITEM_DOCUMENT
+            if (
+                (i.get_type() != ITEM_DOCUMENT)
+                or (
+                    i.file_name in self.exclude_filelist.split(",")
+                    if self.exclude_filelist != ""
+                    else False
+                )
+                or (
+                    not i.file_name in self.only_filelist.split(",")
+                    if self.only_filelist != ""
+                    else False
+                )
+            )
             else len(bs(i.content, "html.parser").findAll(trans_taglist))
             for i in all_items
         )
         all_p_length += self.allow_navigable_strings * sum(
             0
-            if i.get_type() != ITEM_DOCUMENT
+            if (
+                (i.get_type() != ITEM_DOCUMENT)
+                or (
+                    i.file_name in self.exclude_filelist.split(",")
+                    if self.exclude_filelist != ""
+                    else False
+                )
+                or (
+                    not i.file_name in self.only_filelist.split(",")
+                    if self.only_filelist != ""
+                    else False
+                )
+            )
             else len(bs(i.content, "html.parser").findAll(text=True))
             for i in all_items
         )
@@ -464,7 +488,19 @@ class EPUBBookLoader(BaseBookLoader):
         index = 0
         try:
             for item in origin_book_temp.get_items():
-                if item.get_type() == ITEM_DOCUMENT:
+                if (
+                    item.get_type() == ITEM_DOCUMENT
+                    and (
+                        item.file_name not in self.exclude_filelist.split(",")
+                        if self.exclude_filelist != ""
+                        else True
+                    )
+                    and (
+                        item.file_name in self.only_filelist.split(",")
+                        if self.only_filelist != ""
+                        else True
+                    )
+                ):
                     soup = bs(item.content, "html.parser")
                     p_list = soup.findAll(trans_taglist)
                     if self.allow_navigable_strings:

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -405,15 +405,10 @@ class EPUBBookLoader(BaseBookLoader):
             0
             if (
                 (i.get_type() != ITEM_DOCUMENT)
+                or (i.file_name in self.exclude_filelist.split(","))
                 or (
-                    i.file_name in self.exclude_filelist.split(",")
-                    if self.exclude_filelist != ""
-                    else False
-                )
-                or (
-                    not i.file_name in self.only_filelist.split(",")
-                    if self.only_filelist != ""
-                    else False
+                    self.only_filelist
+                    and i.file_name not in self.only_filelist.split(",")
                 )
             )
             else len(bs(i.content, "html.parser").findAll(trans_taglist))
@@ -423,15 +418,10 @@ class EPUBBookLoader(BaseBookLoader):
             0
             if (
                 (i.get_type() != ITEM_DOCUMENT)
+                or (i.file_name in self.exclude_filelist.split(","))
                 or (
-                    i.file_name in self.exclude_filelist.split(",")
-                    if self.exclude_filelist != ""
-                    else False
-                )
-                or (
-                    not i.file_name in self.only_filelist.split(",")
-                    if self.only_filelist != ""
-                    else False
+                    self.only_filelist
+                    and i.file_name not in self.only_filelist.split(",")
                 )
             )
             else len(bs(i.content, "html.parser").findAll(text=True))
@@ -490,15 +480,10 @@ class EPUBBookLoader(BaseBookLoader):
             for item in origin_book_temp.get_items():
                 if (
                     item.get_type() == ITEM_DOCUMENT
-                    and (
-                        item.file_name not in self.exclude_filelist.split(",")
-                        if self.exclude_filelist != ""
-                        else True
-                    )
+                    and (item.file_name not in self.exclude_filelist.split(","))
                     and (
                         item.file_name in self.only_filelist.split(",")
-                        if self.only_filelist != ""
-                        else True
+                        or self.only_filelist != ""
                     )
                 ):
                     soup = bs(item.content, "html.parser")


### PR DESCRIPTION
Two bugs are found when using the exlude_filelist and only_filelist options:

1. progress bars: currently the progress bar adds up the tags for all files in an epub; after the commit it only counts tags in files that will be included.
2. temp file that only translate a subset of files will lead to a mismatch between translated texts and original texts. The commit fixes the bug.