### PR TITLE
chore: setup default backoff for tranlate method

### DIFF
--- a/book_maker/loader/helper.py
+++ b/book_maker/loader/helper.py
@@ -45,9 +45,7 @@ class EPUBBookLoaderHelper:
         self.deal_old(wait_p_list, single_translate, self.context_flag)
         self.insert_trans(
             p,
-            shorter_result_link(
-                self.translate_with_backoff(p.text, self.context_flag)
-            ),
+            shorter_result_link(self.translate_with_backoff(p.text, self.context_flag)),
             self.translation_style,
             single_translate,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .
 mkdocs
 mkdocs-material
+backoff

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ packages = [
     "PyDeepLX",
     "google-generativeai",
     "langdetect",
+    "backoff",
 ]
 
 


### PR DESCRIPTION
sometimes the translating progress would be interrupted by API failure, but after resuming, I get a confusing result about the output #386

This PR append default backoff policy for translation, it would relieve that issue.