### PR TITLE
doc: improve the doc cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Find more info here for using liteLLM: https://github.com/BerriAI/litellm/blob/m
 - Use `--openai_key` option to specify OpenAI API key. If you have multiple keys, separate them by commas (xxx,xxx,xxx) to reduce errors caused by API call limits.
    Or, just set environment variable `BBM_OPENAI_API_KEY` instead.
 - A sample book, `test_books/animal_farm.epub`, is provided for testing purposes.
-- The default underlying model is [GPT-3.5-turbo](https://openai.com/blog/introducing-chatgpt-and-whisper-apis), which is used by ChatGPT currently. Use `--model gpt4` to change the underlying model to `GPT4`.
+- The default underlying model is [GPT-3.5-turbo](https://openai.com/blog/introducing-chatgpt-and-whisper-apis), which is used by ChatGPT currently. Use `--model gpt4` to change the underlying model to `GPT4`. You can also use `GPT4omini`.
   - Important to note that `gpt-4` is significantly more expensive than `gpt-4-turbo`, but to avoid bumping into rate limits, we automatically balance queries across `gpt-4-1106-preview`, `gpt-4`, `gpt-4-32k`, `gpt-4-0613`,`gpt-4-32k-0613`.
     - If you want to use a specific model alias with OpenAI (eg `gpt-4-1106-preview` or `gpt-3.5-turbo-0125`), you can use `--model openai --model_list gpt-4-1106-preview,gpt-3.5-turbo-0125`. `--model_list` takes a comma-separated list of model aliases.
-  - If using `GPT4`, you can add `--use_context` to add a context paragraph to each passage sent to the model for translation (see below).
+  - If using chatgptapi, you can add `--use_context` to add a context paragraph to each passage sent to the model for translation (see below).
 - Support DeepL model [DeepL Translator](https://rapidapi.com/splintPRO/api/dpl-translator) need pay to get the token use `--model deepl --deepl_key ${deepl_key}`
 - Support DeepL free model `--model deeplfree`
 - Support Google [Gemini](https://makersuite.google.com/app/apikey) model `--model gemini --gemini_key ${gemini_key}`
@@ -57,7 +57,11 @@ Find more info here for using liteLLM: https://github.com/BerriAI/litellm/blob/m
 - `--accumulated_num` Wait for how many tokens have been accumulated before starting the translation. gpt3.5 limits the total_token to 4090. For example, if you use --accumulated_num 1600, maybe openai will
 output 2200 tokens and maybe 200 tokens for other messages in the system messages user messages, 1600+2200+200=4000, So you are close to reaching the limit. You have to choose your own
 value, there is no way to know if the limit is reached before sending
-- `--use_context` prompts the GPT4 model to create a one-paragraph summary. If it's the beginning of the translation, it will summarize the entire passage sent (the size depending on `--accumulated_num`), but if it's any proceeding passage, it will amend the summary to include details from the most recent passage, creating a running one-paragraph context payload of the important details of the entire translated work, which improves consistency of flow and tone of each translation.
+- `--use_context` prompts the model to create a three-paragraph summary. If it's the beginning of the translation, it will summarize the entire passage sent (the size depending on `--accumulated_num`). For subsequent passages, it will amend the summary to include details from the most recent passage, creating a running one-paragraph context payload of the important details of the entire translated work. This improves consistency of flow and tone throughout the translation. This option is available for all ChatGPT-compatible models.
+- Use `--context_paragraph_limit` to set a limit on the number of context paragraphs when using the `--use_context` option.
+- Use `--temperature` to set the temperature parameter for `chatgptapi`/`gpt4`/`claude` models. For example: `--temperature 0.7`.
+- Use `--block_size` to merge multiple paragraphs into one block. This may increase accuracy and speed up the process but can disturb the original format. Must be used with `--single_translate`. For example: `--block_size 5`.
+- Use `--single_translate` to output only the translated book without creating a bilingual version.
 - `--translation_style` example: `--translation_style "color: #808080; font-style: italic;"`
 - `--retranslate` `--retranslate "$translated_filepath" "file_name_in_epub" "start_str" "end_str"(optional)`<br>
 Retranslate from start_str to end_str's tag:


### PR DESCRIPTION
### Updated README.md to Reflect Changes in `cli.py`

This PR updates the `README.md` file to reflect recent changes made in the `cli.py` file. The following updates have been made:

1. **Model Options:**
   - Added `GPT4omini` as an option for the `--model` parameter.
   - Clarified that the `--use_context` option is available for all ChatGPT-compatible models, not just `GPT4`.

2. **New Parameters:**
   - Introduced the `--context_paragraph_limit` parameter to set a limit on the number of context paragraphs when using the `--use_context` option.
   - Added the `--temperature` parameter to set the temperature for `chatgptapi`/`gpt4`/`claude` models.
   - Added the `--block_size` parameter to merge multiple paragraphs into one block, which can increase accuracy and speed up the process but may disturb the original format. This must be used with `--single_translate`.
   - Added the `--single_translate` parameter to output only the translated book without creating a bilingual version.

3. **Context Summary:**
   - Updated the description of the `--use_context` parameter to indicate that it now creates a three-paragraph summary at the beginning and a running one-paragraph context payload for subsequent passages, improving consistency of flow and tone throughout the translation.

These changes ensure that the documentation is up-to-date with the latest features and options available in the `cli.py` script.