### PR TITLE
Avoid crash if not provide book_name

### DIFF
--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -325,8 +325,11 @@ So you are close to reaching the limit. You have to choose your own value, there
 
     options = parser.parse_args()
 
+    if not options.book_name:
+        print(f"Error: please provide the path of your book using --book_name <path>")
+        exit(1)
     if not os.path.isfile(options.book_name):
-        print(f"Error: {options.book_name} does not exist.")
+        print(f"Error: the book {options.book_name!r} does not exist.")
         exit(1)
 
     PROXY = options.proxy


### PR DESCRIPTION
Instead of showing an ugly crash message like the one below to the user when they don't provide any arguments, it would be better to display a more user-friendly message:
```
❯ bbook_maker
Traceback (most recent call last):
  File "/Users/xyb/.virtualenvs/bilingual_book_maker/bin/bbook_maker", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/xyb/projects/bilingual_book_maker/book_maker/cli.py", line 328, in main
    if not os.path.isfile(options.book_name):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen genericpath>", line 30, in isfile
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```
A more appropriate message would be:
```
❯ bbook_maker
Error: please provide the path of your book using --book_name <path>
```