### PR TITLE
Fix claude temperature and update model

### DIFF
--- a/book_maker/translator/claude_translator.py
+++ b/book_maker/translator/claude_translator.py
@@ -19,12 +19,13 @@ class Claude(Base):
         super().__init__(key, language)
         self.api_url = f"{api_base}" if api_base else "https://api.anthropic.com"
         self.client = Anthropic(base_url=api_base, api_key=key, timeout=20)
-
+        self.model = "claude-3-5-sonnet-20241022"  # default it for now
         self.language = language
         self.prompt_template = (
             prompt_template
             or "\n\nHuman: Help me translate the text within triple backticks into {language} and provide only the translated result.\n```{text}```\n\nAssistant: "
         )
+        self.temperature = temperature
 
     def rotate_key(self):
         pass
@@ -40,7 +41,8 @@ class Claude(Base):
         r = self.client.messages.create(
             max_tokens=4096,
             messages=message,
-            model="claude-3-haiku-20240307",  # default it for now
+            temperature=self.temperature,
+            model=self.model,
         )
         t_text = r.content[0].text
         # api limit rate and spider rule


### PR DESCRIPTION
Support for setting temperature with Claude was added in #278 but then lost in 70d2535f84de75d6460096ccf2ea64d1af9710e0. This adds back support for setting temperature with Claude.

It also updates the default model for Claude to the latest Claude 3.5 Sonnet model, which is much better at translating books than the old Claude 3 Haiku model.