### PR TITLE
Add promptdown support (markdown user, system, developer messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   - If you don't need to set the `system` role content, you can simply set it up like this: `--prompt "Translate {text} to {language}."` or `--prompt prompt_template_sample.txt` (example of a text file can be found at [./prompt_template_sample.txt](./prompt_template_sample.txt)).
 
   - If you need to set the `system` role content, you can use the following format: `--prompt '{"user":"Translate {text} to {language}", "system": "You are a professional translator."}'` or `--prompt prompt_template_sample.json` (example of a JSON file can be found at [./prompt_template_sample.json](./prompt_template_sample.json)).
+  
+  - You can now use [PromptDown](https://github.com/btfranklin/promptdown) format (`.md` files) for more structured prompts: `--prompt prompt_md.prompt.md`. PromptDown supports both traditional system messages and developer messages (used by newer AI models). Example:
+  
+      ```markdown
+      # Translation Prompt
+      
+      ## Developer Message
+      You are a professional translator who specializes in accurate translations.
+      
+      ## Conversation
+      
+      | Role  | Content                                           |
+      |-------|---------------------------------------------------|
+      | User  | Please translate the following text into {language}:\n\n{text} |
+      ```
 
   - You can also set the `user` and `system` role prompt by setting environment variables: `BBM_CHATGPTAPI_USER_MSG_TEMPLATE` and `BBM_CHATGPTAPI_SYS_MSG`.
 

--- a/docs/prompt.md
+++ b/docs/prompt.md
@@ -19,6 +19,32 @@ To tweak the prompt, use the `--prompt` parameter. Valid placeholders for the `u
 
 You can also set the `user` and `system` role prompt by setting environment variables: `BBM_CHATGPTAPI_USER_MSG_TEMPLATE` and `BBM_CHATGPTAPI_SYS_MSG`.
 
+- You can now use PromptDown format (`.md` files) for more structured prompts: `--prompt prompt_md.prompt.md`
+
+        # Translation Prompt
+        
+        ## System Message
+        You are a professional translator who specializes in accurate translations.
+        
+        ## Conversation
+        
+        | Role  | Content                                  |
+        |-------|------------------------------------------|
+        | User  | Please translate the following text into {language}:\n\n{text} |
+        
+        # OR using Developer Message (for newer AI models)
+        
+        # Translation Prompt
+        
+        ## Developer Message
+        You are a professional translator who specializes in accurate translations.
+        
+        ## Conversation
+        
+        | Role  | Content                                  |
+        |-------|------------------------------------------|
+        | User  | Please translate the following text into {language}:\n\n{text} |
+
 ## Examples
 ```sh
 python3 make_book.py --book_name test_books/animal_farm.epub --prompt prompt_template_sample.txt

--- a/prompt_md.prompt.md
+++ b/prompt_md.prompt.md
@@ -1,0 +1,11 @@
+# Translation Prompt
+
+## Developer Message
+
+You are a professional translator who specializes in accurate, natural-sounding translations that preserve the original meaning, tone, and style of the text.
+
+## Conversation
+
+| Role  | Content                                                                   |
+|-------|---------------------------------------------------------------------------|
+| User  | Please translate the following text into {language}:\n\n{text}            |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "The bilingual_book_maker is an AI translation tool that uses Chat
 readme = "README.md"
 license = {text = "MIT"}
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "yihong0618", email = "zouzou0208@gmail.com" },
 ]
@@ -28,10 +28,12 @@ dependencies = [
     "tiktoken",
     "tqdm",
     "groq>=0.5.0",
+    "promptdown>=0.9.0",
 ]
 
 [project.scripts]
 bbook_maker = "book_maker.cli:main"
+promptdown = "promptdown_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/yihong0618/bilingual_book_maker"

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ mdurl==0.1.2
 multidict==6.0.5
 openai==1.30.3
 packaging==24.0
+promptdown==0.9.0
 proto-plus==1.23.0
 protobuf==4.25.3
 pyasn1==0.6.0


### PR DESCRIPTION
You can now use [PromptDown](https://github.com/btfranklin/promptdown) format (`.md` files) for more structured prompts: `--prompt prompt_md.prompt.md`. PromptDown supports both traditional system messages and developer messages (used by newer AI models). Example:

      ```markdown
      # Translation Prompt

      ## Developer Message
      You are a professional translator who specializes in accurate translations.

      ## Conversation

      | Role  | Content                                           |
      |-------|---------------------------------------------------|
      | User  | Please translate the following text into {language}:\n\n{text} |
      ```


Additional testing welcome. Work for my use-case.