### PR TITLE
feat(model): add gpt-5-mini model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist u
 
 ## Supported Models
 
-gpt-4, gpt-3.5-turbo, claude-2, palm, llama-2, azure-openai, command-nightly, gemini, qwen-mt-turbo, qwen-mt-plus
+gpt-5-mini, gpt-4, gpt-3.5-turbo, claude-2, palm, llama-2, azure-openai, command-nightly, gemini, qwen-mt-turbo, qwen-mt-plus
 For using Non-OpenAI models, use class `liteLLM()` - liteLLM supports all models above.
 Find more info here for using liteLLM: https://github.com/BerriAI/litellm/blob/main/setup.py
 

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -360,7 +360,7 @@ So you are close to reaching the limit. You have to choose your own value, there
         "--temperature",
         type=float,
         default=1.0,
-        help="temperature parameter for `chatgptapi`/`gpt4`/`claude`/`gemini`",
+        help="temperature parameter for `chatgptapi`/`gpt4`/`gpt4omini`/`gpt4o`/`gpt5mini`/`claude`/`gemini`",
     )
     parser.add_argument(
         "--source_lang",
@@ -429,6 +429,7 @@ So you are close to reaching the limit. You have to choose your own value, there
         "gpt4",
         "gpt4omini",
         "gpt4o",
+        "gpt5mini",
         "o1preview",
         "o1",
         "o1mini",
@@ -559,6 +560,7 @@ So you are close to reaching the limit. You have to choose your own value, there
             "gpt4",
             "gpt4omini",
             "gpt4o",
+            "gpt5mini",
             "o1",
             "o1preview",
             "o1mini",
@@ -573,7 +575,7 @@ So you are close to reaching the limit. You have to choose your own value, there
             e.translate_model.set_model_list(options.model_list.split(","))
         else:
             raise ValueError(
-                "When using `openai` model, you must also provide `--model_list`. For default model sets use `--model chatgptapi` or `--model gpt4` or `--model gpt4omini`",
+                "When using `openai` model, you must also provide `--model_list`. For default model sets use `--model chatgptapi` or `--model gpt4` or `--model gpt4omini` or `--model gpt5mini`",
             )
     # TODO refactor, quick fix for gpt4 model
     if options.model == "chatgptapi":
@@ -587,6 +589,8 @@ So you are close to reaching the limit. You have to choose your own value, there
         e.translate_model.set_gpt4omini_models()
     if options.model == "gpt4o":
         e.translate_model.set_gpt4o_models()
+    if options.model == "gpt5mini":
+        e.translate_model.set_gpt5mini_models()
     if options.model == "o1preview":
         e.translate_model.set_o1preview_models()
     if options.model == "o1":

--- a/book_maker/translator/__init__.py
+++ b/book_maker/translator/__init__.py
@@ -17,6 +17,7 @@ MODEL_DICT = {
     "gpt4": ChatGPTAPI,
     "gpt4omini": ChatGPTAPI,
     "gpt4o": ChatGPTAPI,
+    "gpt5mini": ChatGPTAPI,
     "o1preview": ChatGPTAPI,
     "o1": ChatGPTAPI,
     "o1mini": ChatGPTAPI,

--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -49,6 +49,9 @@ GPT4o_MODEL_LIST = [
     "gpt-4o-2024-08-06",
     "chatgpt-4o-latest",
 ]
+GPT5MINI_MODEL_LIST = [
+    "gpt-5-mini",
+]
 O1PREVIEW_MODEL_LIST = [
     "o1-preview",
     "o1-preview-2024-09-12",
@@ -488,6 +491,18 @@ class ChatGPTAPI(Base):
                 i["id"] for i in self.openai_client.models.list().model_dump()["data"]
             ]
             model_list = list(set(my_model_list) & set(GPT4o_MODEL_LIST))
+            print(f"Using model list {model_list}")
+            self.model_list = cycle(model_list)
+
+    def set_gpt5mini_models(self):
+        # for issue #375 azure can not use model list
+        if self.deployment_id:
+            self.model_list = cycle(["gpt-5-mini"])
+        else:
+            my_model_list = [
+                i["id"] for i in self.openai_client.models.list().model_dump()["data"]
+            ]
+            model_list = list(set(my_model_list) & set(GPT5MINI_MODEL_LIST))
             print(f"Using model list {model_list}")
             self.model_list = cycle(model_list)
 

--- a/docs/model_lang.md
+++ b/docs/model_lang.md
@@ -2,12 +2,12 @@
 ## Models
 `-m, --model <Model>` <br>
 
-Currently `bbook_maker` supports these models: `chatgptapi` , `gpt3` , `google` , `caiyun` , `deepl` , `deeplfree` , `gpt4` , `gpt4omini` , `o1-preview` , `o1` , `o1-mini` , `o3-mini` , `claude` , `customapi`.
+Currently `bbook_maker` supports these models: `chatgptapi` , `gpt3` , `google` , `caiyun` , `deepl` , `deeplfree` , `gpt4` , `gpt4omini` , `gpt5mini` , `o1-preview` , `o1` , `o1-mini` , `o3-mini` , `claude` , `customapi`.
 Default model is `chatgptapi` . 
 
 ### OPENAI models
 
-There are three models you can choose from.
+There are several models you can choose from.
 
 * gpt3
 
@@ -46,6 +46,12 @@ There are three models you can choose from.
     
 
     If it has any proceeding passage, it will amend the summary to include details from the most recent passage, creating a running one-paragraph context payload of the important details of the entire translated work, which improves consistency of flow and tone of each translation.
+
+* gpt5mini
+
+    `gpt5mini` uses the `gpt-5-mini` model.
+
+        bbook_maker --book_name test_books/animal_farm.epub --model gpt5mini --openai_key ${openai_key}
 
 **Note 1: Use `--openai_key` option to specify OpenAI API key. If you have multiple keys, separate them by commas (xxx, xxx, xxx) to reduce errors caused by API call limits.**
 


### PR DESCRIPTION
  ## Summary
  - add `gpt5mini` CLI model option mapped to OpenAI `gpt-5-mini`
  - wire model selection into ChatGPTAPI model lists and CLI handling
  - document the new model in English/Chinese docs