### PR TITLE
fix: update new_p.string when resuming with single_translate

### DIFF
--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -221,6 +221,7 @@ class EPUBBookLoader(BaseBookLoader):
     def _process_paragraph(self, p, new_p, index, p_to_save_len, thread_safe=False):
         if self.resume and index < p_to_save_len:
             p.string = self.p_to_save[index]
+            new_p.string = self.p_to_save[index]  # Fix: also update new_p to cached translation
         else:
             t_text = ""
             if self.batch_flag:


### PR DESCRIPTION
  When using --resume with --single_translate, the cached translation
  was loaded into p.string but new_p.string was still the original text.
  This caused insert_trans to receive the original text instead of the
  translation, resulting in English output instead of Chinese.

---

 **Bug 描述**
  使用 `--resume` 和 `--single_translate` 参数时，输出的仍是英文原文而非中文翻译。

  **根因**
  `_process_paragraph` 中恢复缓存时只更新了 `p.string`，但 `insert_trans` 使用的是 `new_p.string`。

  **修复**
  在 resume 时也同步更新 `new_p.string`。