### PR TITLE
feat: add custom API provider support via JSON config

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -111,6 +111,53 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 make_book.py --book_name test_books/animal_farm.epub --groq_key [your_key] --model groq --model_list llama3-8b-8192
   ```
 
+* 自定义 API Provider
+
+  内置模型不满足需求时，可以通过 JSON 配置文件自定义 provider。不需要改代码，就能使用任何 OpenAI 兼容的 API（DeepSeek、SiliconFlow、本地代理等）。
+
+  在当前目录创建 `bbm_providers.json`（全局配置放在 `~/.bbm/providers.json`）：
+
+  ```json
+  {
+    "providers": {
+      "deepseek": {
+        "api_style": "openai",
+        "base_url": "https://api.deepseek.com/v1",
+        "default_models": ["deepseek-chat", "deepseek-reasoner"],
+        "env_key": "BBM_DEEPSEEK_API_KEY"
+      },
+      "siliconflow": {
+        "api_style": "openai",
+        "base_url": "https://api.siliconflow.cn/v1",
+        "default_models": ["Qwen/Qwen2.5-72B-Instruct"],
+        "env_key": "BBM_SILICONFLOW_API_KEY"
+      }
+    }
+  }
+  ```
+
+  配置字段说明：
+
+  | 字段 | 必填 | 说明 |
+  |------|------|------|
+  | `api_style` | 是 | 翻译器接口风格。支持：`openai`、`claude`、`gemini`、`qwen` |
+  | `base_url` | 否 | API 地址。不填则使用该 api_style 的默认地址 |
+  | `default_models` | 否 | 默认模型列表。不填则必须通过 `--model_list` 指定 |
+  | `env_key` | 否 | 读取 API key 的环境变量名。不填则必须通过 `--api_key` 传入 |
+
+  优先级：项目级 `./bbm_providers.json` 覆盖全局 `~/.bbm/providers.json`。
+
+  `--provider` 和 `--model` 互斥，不能同时使用。
+
+  ```shell
+  python3 make_book.py --provider deepseek --api_key sk-xxx --book_name test_books/animal_farm.epub
+
+  export BBM_DEEPSEEK_API_KEY=sk-xxx
+  python3 make_book.py --provider deepseek --book_name test_books/animal_farm.epub
+
+  python3 make_book.py --provider deepseek --api_key sk-xxx --model_list deepseek-reasoner --book_name test_books/animal_farm.epub
+  ```
+
 ## 使用说明
 
 - 翻译完会生成一本 `{book_name}_bilingual.epub` 的双语书
@@ -220,6 +267,14 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which'
   ```
 
+- `--provider`:
+
+  使用 `bbm_providers.json` 中定义的自定义 provider。与 `--model` 互斥。详见上方「自定义 API Provider」章节。
+
+- `--api_key`:
+
+  自定义 provider 的 API key（与 `--provider` 配合使用）。也可通过配置文件中的 `env_key` 字段指定环境变量。
+
 ### 示范用例
 
 **如果使用 `pip install bbook_maker` 以下命令都可以改成 `bbook args`**
@@ -245,6 +300,9 @@ python3 make_book.py --book_name test_books/animal_farm.epub --model claude --cl
 
 # Use the CustomAPI model with Japanese
 python3 make_book.py --book_name test_books/animal_farm.epub --model customapi --custom_api ${custom_api} --language ja
+
+# 使用自定义 provider（如 DeepSeek）
+python3 make_book.py --book_name test_books/animal_farm.epub --provider deepseek --api_key sk-xxx --language ja
 
 # Translate contents in <div> and <p>
 python3 make_book.py --book_name test_books/animal_farm.epub --translate-tags div,p

--- a/README-CN.md
+++ b/README-CN.md
@@ -165,6 +165,38 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 
 ## 参数说明
 
+- `--model`:
+
+  指定翻译模型。默认：`chatgptapi`。各模型值及其行为：
+
+  | 模型 | Key 来源 | 说明 |
+  |------|---------|------|
+  | `chatgptapi` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-3.5-turbo，自动检测 API 可用模型 |
+  | `gpt4` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-4 系列，自动在可用变体间负载均衡 |
+  | `gpt4omini` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-4o-mini |
+  | `gpt4o` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-4o |
+  | `gpt5mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-5-mini |
+  | `o1preview` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1-preview |
+  | `o1` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1 |
+  | `o1mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1-mini |
+  | `o3mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o3-mini |
+  | `openai` | `--openai_key` / `BBM_OPENAI_API_KEY` | **必须配合 `--model_list`**，可使用任意 OpenAI 兼容模型 |
+  | `claude-*` | `--claude_key` / `BBM_CLAUDE_API_KEY` | 前缀匹配，如 `--model claude-sonnet-4-20250514` |
+  | `gemini` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Flash，支持 `--model_list` 自定义 |
+  | `geminipro` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Pro |
+  | `groq` | `--groq_key` / `BBM_GROQ_API_KEY` | **必须配合 `--model_list`** |
+  | `xai` | `--xai_key` / `BBM_XAI_API_KEY` | Grok |
+  | `qwen-mt-turbo` | `--qwen_key` / `BBM_QWEN_API_KEY` | 通义千问快速翻译模型 |
+  | `qwen-mt-plus` | `--qwen_key` / `BBM_QWEN_API_KEY` | 通义千问高质量翻译模型 |
+  | `google` | 无需 key | 免费谷歌翻译 |
+  | `caiyun` | `--caiyun_key` / `BBM_CAIYUN_API_KEY` | 彩云小译 |
+  | `deepl` | `--deepl_key` / `BBM_DEEPL_API_KEY` | DeepL（付费） |
+  | `deeplfree` | 无需 key | DeepL 免费版 |
+  | `tencentransmart` | 无需 key | 腾讯交互翻译，免费 |
+  | `customapi` | `--custom_api` / `BBM_CUSTOM_API` | 自定义翻译 API |
+
+  上表未列出的 OpenAI 兼容 API，请使用 `--provider`（见「自定义 API Provider」章节）。
+
 - `--test`:
 
   如果大家没付费可以加上这个先看看效果（有 limit 稍微有些慢）

--- a/README.md
+++ b/README.md
@@ -125,6 +125,53 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 make_book.py --book_name test_books/animal_farm.epub --groq_key [your_key] --model groq --model_list llama3-8b-8192
   ```
 
+* Custom API Provider
+
+  If the built-in models don't cover your needs, you can define custom providers via a JSON config file. This lets you use any OpenAI-compatible API (DeepSeek, SiliconFlow, local proxies, etc.) without modifying source code.
+
+  Create `bbm_providers.json` in the current directory (or `~/.bbm/providers.json` for global config):
+
+  ```json
+  {
+    "providers": {
+      "deepseek": {
+        "api_style": "openai",
+        "base_url": "https://api.deepseek.com/v1",
+        "default_models": ["deepseek-chat", "deepseek-reasoner"],
+        "env_key": "BBM_DEEPSEEK_API_KEY"
+      },
+      "siliconflow": {
+        "api_style": "openai",
+        "base_url": "https://api.siliconflow.cn/v1",
+        "default_models": ["Qwen/Qwen2.5-72B-Instruct"],
+        "env_key": "BBM_SILICONFLOW_API_KEY"
+      }
+    }
+  }
+  ```
+
+  Config fields:
+
+  | Field | Required | Description |
+  |-------|----------|-------------|
+  | `api_style` | Yes | Translator interface style. Supported: `openai`, `claude`, `gemini`, `qwen` |
+  | `base_url` | No | API endpoint URL. Falls back to the api_style's default |
+  | `default_models` | No | Default model list. Required if `--model_list` is not provided |
+  | `env_key` | No | Environment variable name for API key. Required if `--api_key` is not provided |
+
+  Priority: project-level `./bbm_providers.json` overrides global `~/.bbm/providers.json`.
+
+  `--provider` and `--model` are mutually exclusive.
+
+  ```shell
+  python3 make_book.py --provider deepseek --api_key sk-xxx --book_name test_books/animal_farm.epub
+
+  export BBM_DEEPSEEK_API_KEY=sk-xxx
+  python3 make_book.py --provider deepseek --book_name test_books/animal_farm.epub
+
+  python3 make_book.py --provider deepseek --api_key sk-xxx --model_list deepseek-reasoner --book_name test_books/animal_farm.epub
+  ```
+
 ## Use
 
 - Once the translation is complete, a bilingual book named `${book_name}_bilingual.epub` would be generated for EPUB inputs; for TXT/MD/SRT inputs a bilingual text (or subtitle) file named `${book_name}_bilingual.txt` (or `_bilingual.srt`) will be generated. For **PDF inputs** the tool will produce a bilingual `.txt` fallback and will also attempt to create `${book_name}_bilingual.epub` — if EPUB creation fails, the TXT fallback remains so you do not need to retranslate.
@@ -267,6 +314,14 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 make_book.py --book_name test_books/animal_farm.epub --openai_key ${openai_key} --extra_body '{"chat_template_kwargs": {"enable_thinking": false}}'
   ```
 
+- `--provider`:
+
+  Use a custom provider defined in `bbm_providers.json`. Mutually exclusive with `--model`. See the "Custom API Provider" section above.
+
+- `--api_key`:
+
+  API key for custom providers (used with `--provider`). Can also be set via the `env_key` field in the provider config.
+
 ### Examples
 
 **Note if use `pip install bbook_maker` all commands can change to `bbook_maker args`**
@@ -313,6 +368,9 @@ python3 make_book.py --book_name test_books/animal_farm.epub --model claude --cl
 
 # Use the CustomAPI model with Japanese
 python3 make_book.py --book_name test_books/animal_farm.epub --model customapi --custom_api ${custom_api} --language ja
+
+# Use a custom provider (e.g. DeepSeek)
+python3 make_book.py --book_name test_books/animal_farm.epub --provider deepseek --api_key sk-xxx --language ja
 
 # Translate contents in <div> and <p>
 python3 make_book.py --book_name test_books/animal_farm.epub --translate-tags div,p

--- a/README.md
+++ b/README.md
@@ -179,6 +179,38 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 
 ## Params
 
+- `--model`:
+
+  Select the translation model. Default: `chatgptapi`. Available values and their behavior:
+
+  | Model | Key Source | Notes |
+  |-------|-----------|-------|
+  | `chatgptapi` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-3.5-turbo. Auto-detects available models from API |
+  | `gpt4` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-4 family. Auto-balances across available GPT-4 variants |
+  | `gpt4omini` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-4o-mini |
+  | `gpt4o` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-4o |
+  | `gpt5mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | GPT-5-mini |
+  | `o1preview` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1-preview |
+  | `o1` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1 |
+  | `o1mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1-mini |
+  | `o3mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o3-mini |
+  | `openai` | `--openai_key` / `BBM_OPENAI_API_KEY` | **Requires `--model_list`**. Use any OpenAI-compatible model |
+  | `claude-*` | `--claude_key` / `BBM_CLAUDE_API_KEY` | Prefix match. e.g. `--model claude-sonnet-4-20250514` |
+  | `gemini` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Flash. Supports `--model_list` |
+  | `geminipro` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Pro |
+  | `groq` | `--groq_key` / `BBM_GROQ_API_KEY` | **Requires `--model_list`** |
+  | `xai` | `--xai_key` / `BBM_XAI_API_KEY` | Grok |
+  | `qwen-mt-turbo` | `--qwen_key` / `BBM_QWEN_API_KEY` | Qwen fast translation model |
+  | `qwen-mt-plus` | `--qwen_key` / `BBM_QWEN_API_KEY` | Qwen high-quality translation model |
+  | `google` | N/A | Free. No API key needed |
+  | `caiyun` | `--caiyun_key` / `BBM_CAIYUN_API_KEY` | Caiyun |
+  | `deepl` | `--deepl_key` / `BBM_DEEPL_API_KEY` | DeepL (paid) |
+  | `deeplfree` | N/A | DeepL Free |
+  | `tencentransmart` | N/A | Tencent TranSmart. Free |
+  | `customapi` | `--custom_api` / `BBM_CUSTOM_API` | Custom translation API |
+
+  For any OpenAI-compatible API not listed above, use `--provider` instead (see Custom API Provider section).
+
 - `--test`:
 
   Use `--test` option to preview the result if you haven't paid for the service. Note that there is a limit and it may take some time.

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -7,6 +7,7 @@ from rich import print
 
 from book_maker.loader import BOOK_LOADER_DICT
 from book_maker.translator import MODEL_DICT
+from book_maker.provider_loader import get_provider, get_translator_class
 from book_maker.utils import LANGUAGES, TO_LANGUAGE_CODE
 
 
@@ -212,7 +213,7 @@ def main():
         "--model",
         dest="model",
         type=str,
-        default="chatgptapi",
+        default=None,
         choices=translate_model_list,  # support DeepL later
         metavar="MODEL",
         help="model to use, available: {%(choices)s}",
@@ -414,8 +415,24 @@ So you are close to reaching the limit. You have to choose your own value, there
         default="",
         help='JSON string of extra body parameters to pass to the API. Example: --extra_body \'{"chat_template_kwargs": {"enable_thinking": false}}\'',
     )
+    parser.add_argument(
+        "--provider",
+        dest="provider",
+        type=str,
+        help="Use a custom provider defined in bbm_providers.json (mutually exclusive with --model)",
+    )
+    parser.add_argument(
+        "--api_key",
+        dest="api_key",
+        type=str,
+        default="",
+        help="API key for custom providers (used with --provider)",
+    )
 
     options = parser.parse_args()
+
+    if options.provider and options.model:
+        parser.error("--provider and --model are mutually exclusive")
 
     if not options.book_name:
         print("Error: please provide the path of your book using --book_name <path>")
@@ -429,7 +446,15 @@ So you are close to reaching the limit. You have to choose your own value, there
         os.environ["http_proxy"] = PROXY
         os.environ["https_proxy"] = PROXY
 
-    translate_model = MODEL_DICT.get(options.model)
+    provider_cfg = None
+    if options.provider:
+        provider_cfg = get_provider(options.provider)
+        translate_model = get_translator_class(provider_cfg["api_style"])
+    elif options.model:
+        translate_model = MODEL_DICT.get(options.model)
+    else:
+        translate_model = MODEL_DICT.get("chatgptapi")
+        options.model = "chatgptapi"
     assert translate_model is not None, "unsupported model"
     API_KEY = ""
     if options.model in [
@@ -486,6 +511,12 @@ So you are close to reaching the limit. You have to choose your own value, there
         API_KEY = options.xai_key or env.get("BBM_XAI_API_KEY")
     elif options.model.startswith("qwen-"):
         API_KEY = options.qwen_key or env.get("BBM_QWEN_API_KEY")
+    elif options.provider:
+        env_key_name = provider_cfg.get("env_key", "") if provider_cfg else ""
+        API_KEY = options.api_key or (env.get(env_key_name) if env_key_name else "")
+        if not API_KEY:
+            hint = f" or set {env_key_name}" if env_key_name else ""
+            raise Exception(f"Please provide API key via --api_key{hint}")
     else:
         API_KEY = ""
 
@@ -519,6 +550,9 @@ So you are close to reaching the limit. You have to choose your own value, there
     if options.ollama_model and not model_api_base:
         # ollama default api_base
         model_api_base = "http://localhost:11434/v1"
+
+    if options.provider and provider_cfg and not model_api_base:
+        model_api_base = provider_cfg.get("base_url")
 
     e = book_loader(
         options.book_name,
@@ -641,6 +675,18 @@ So you are close to reaching the limit. You have to choose your own value, there
             e.translate_model.set_geminiflash_models()
     if options.model == "geminipro":
         e.translate_model.set_geminipro_models()
+
+    if options.provider and provider_cfg:
+        if options.model_list:
+            e.translate_model.set_model_list(options.model_list.split(","))
+        else:
+            default_models = provider_cfg.get("default_models", [])
+            if default_models:
+                e.translate_model.set_model_list(default_models)
+            else:
+                raise ValueError(
+                    "Provider has no default_models. Please provide --model_list"
+                )
 
     e.make_bilingual_book()
 

--- a/book_maker/provider_loader.py
+++ b/book_maker/provider_loader.py
@@ -1,0 +1,101 @@
+import json
+import os
+from pathlib import Path
+
+from book_maker.translator.chatgptapi_translator import ChatGPTAPI
+from book_maker.translator.claude_translator import Claude
+from book_maker.translator.gemini_translator import Gemini
+from book_maker.translator.qwen_translator import QwenTranslator
+
+SUPPORTED_API_STYLES = {
+    "openai": ChatGPTAPI,
+    "claude": Claude,
+    "gemini": Gemini,
+    "qwen": QwenTranslator,
+}
+
+GLOBAL_CONFIG_PATH = Path.home() / ".bbm" / "providers.json"
+LOCAL_CONFIG_FILENAME = "bbm_providers.json"
+
+REQUIRED_FIELDS = {"api_style"}
+OPTIONAL_FIELDS = {"base_url", "default_models", "env_key"}
+ALL_VALID_FIELDS = REQUIRED_FIELDS | OPTIONAL_FIELDS
+
+
+def _load_json_file(path):
+    if not os.path.isfile(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _merge_configs(global_config, local_config):
+    if not global_config and not local_config:
+        return {"providers": {}}
+    if not global_config:
+        return local_config
+    if not local_config:
+        return global_config
+    merged = dict(global_config.get("providers", {}))
+    merged.update(local_config.get("providers", {}))
+    return {"providers": merged}
+
+
+def load_provider_config():
+    global_cfg = _load_json_file(GLOBAL_CONFIG_PATH)
+    local_path = os.path.join(os.getcwd(), LOCAL_CONFIG_FILENAME)
+    local_cfg = _load_json_file(local_path)
+    return _merge_configs(global_cfg, local_cfg)
+
+
+def get_provider(name):
+    config = load_provider_config()
+    providers = config.get("providers", {})
+    if name not in providers:
+        raise ValueError(
+            f"Provider '{name}' not found in config. "
+            f"Available providers: {list(providers.keys())}"
+        )
+    provider = providers[name]
+    validate_provider(name, provider)
+    return provider
+
+
+def validate_provider(name, provider):
+    if not isinstance(provider, dict):
+        raise ValueError(f"Provider '{name}' must be a JSON object")
+
+    missing = REQUIRED_FIELDS - set(provider.keys())
+    if missing:
+        raise ValueError(f"Provider '{name}' missing required fields: {missing}")
+
+    unknown = set(provider.keys()) - ALL_VALID_FIELDS
+    if unknown:
+        raise ValueError(f"Provider '{name}' has unknown fields: {unknown}")
+
+    api_style = provider["api_style"]
+    if api_style not in SUPPORTED_API_STYLES:
+        raise ValueError(
+            f"Provider '{name}' has unsupported api_style '{api_style}'. "
+            f"Supported: {list(SUPPORTED_API_STYLES.keys())}"
+        )
+
+    default_models = provider.get("default_models")
+    if default_models is not None:
+        if not isinstance(default_models, list) or not all(
+            isinstance(m, str) for m in default_models
+        ):
+            raise ValueError(
+                f"Provider '{name}': default_models must be a list of strings"
+            )
+        if len(default_models) == 0:
+            raise ValueError(f"Provider '{name}': default_models must not be empty")
+
+
+def get_translator_class(api_style):
+    if api_style not in SUPPORTED_API_STYLES:
+        raise ValueError(
+            f"Unsupported api_style '{api_style}'. "
+            f"Supported: {list(SUPPORTED_API_STYLES.keys())}"
+        )
+    return SUPPORTED_API_STYLES[api_style]

--- a/tests/test_provider_loader.py
+++ b/tests/test_provider_loader.py
@@ -15,7 +15,6 @@ from book_maker.translator.claude_translator import Claude
 from book_maker.translator.gemini_translator import Gemini
 from book_maker.translator.qwen_translator import QwenTranslator
 
-
 VALID_DEEPSEEK = {
     "api_style": "openai",
     "base_url": "https://api.deepseek.com/v1",

--- a/tests/test_provider_loader.py
+++ b/tests/test_provider_loader.py
@@ -1,0 +1,204 @@
+import json
+import os
+import pytest
+
+from book_maker.provider_loader import (
+    _merge_configs,
+    get_provider,
+    get_translator_class,
+    load_provider_config,
+    validate_provider,
+    SUPPORTED_API_STYLES,
+)
+from book_maker.translator.chatgptapi_translator import ChatGPTAPI
+from book_maker.translator.claude_translator import Claude
+from book_maker.translator.gemini_translator import Gemini
+from book_maker.translator.qwen_translator import QwenTranslator
+
+
+VALID_DEEPSEEK = {
+    "api_style": "openai",
+    "base_url": "https://api.deepseek.com/v1",
+    "default_models": ["deepseek-chat"],
+    "env_key": "BBM_DEEPSEEK_API_KEY",
+}
+
+VALID_MINIMAL = {
+    "api_style": "openai",
+}
+
+VALID_CLAUDE_STYLE = {
+    "api_style": "claude",
+    "base_url": "https://api.anthropic.com",
+    "default_models": ["claude-sonnet-4-20250514"],
+}
+
+
+@pytest.fixture
+def tmp_global_config(tmp_path, monkeypatch):
+    import book_maker.provider_loader as mod
+
+    config_dir = tmp_path / ".bbm"
+    config_dir.mkdir()
+    config_file = config_dir / "providers.json"
+    monkeypatch.setattr(mod, "GLOBAL_CONFIG_PATH", config_file)
+    return config_file
+
+
+@pytest.fixture
+def tmp_local_config(tmp_path, monkeypatch):
+    import book_maker.provider_loader as mod
+
+    config_file = tmp_path / "bbm_providers.json"
+    monkeypatch.setattr(mod, "LOCAL_CONFIG_FILENAME", "bbm_providers.json")
+    monkeypatch.chdir(tmp_path)
+    return config_file
+
+
+def _write_json(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+class TestValidateProvider:
+    def test_valid_full_config(self):
+        validate_provider("deepseek", VALID_DEEPSEEK)
+
+    def test_valid_minimal(self):
+        validate_provider("myprovider", VALID_MINIMAL)
+
+    def test_valid_claude_style(self):
+        validate_provider("my_claude", VALID_CLAUDE_STYLE)
+
+    def test_missing_api_style(self):
+        with pytest.raises(ValueError, match="missing required fields"):
+            validate_provider("bad", {"base_url": "https://example.com"})
+
+    def test_unsupported_api_style(self):
+        with pytest.raises(ValueError, match="unsupported api_style"):
+            validate_provider("bad", {"api_style": "nonexistent"})
+
+    def test_unknown_field(self):
+        with pytest.raises(ValueError, match="unknown fields"):
+            validate_provider("bad", {"api_style": "openai", "typo_field": "x"})
+
+    def test_default_models_not_list(self):
+        with pytest.raises(ValueError, match="must be a list of strings"):
+            validate_provider("bad", {"api_style": "openai", "default_models": "gpt-4"})
+
+    def test_default_models_empty(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            validate_provider("bad", {"api_style": "openai", "default_models": []})
+
+    def test_default_models_non_string_element(self):
+        with pytest.raises(ValueError, match="must be a list of strings"):
+            validate_provider("bad", {"api_style": "openai", "default_models": [123]})
+
+    def test_non_dict_provider(self):
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            validate_provider("bad", "not a dict")
+
+
+class TestMergeConfigs:
+    def test_both_none(self):
+        result = _merge_configs(None, None)
+        assert result == {"providers": {}}
+
+    def test_global_only(self):
+        global_cfg = {"providers": {"deepseek": VALID_DEEPSEEK}}
+        result = _merge_configs(global_cfg, None)
+        assert "deepseek" in result["providers"]
+
+    def test_local_only(self):
+        local_cfg = {"providers": {"deepseek": VALID_DEEPSEEK}}
+        result = _merge_configs(None, local_cfg)
+        assert "deepseek" in result["providers"]
+
+    def test_local_overrides_global(self):
+        global_cfg = {
+            "providers": {
+                "deepseek": {"api_style": "openai", "base_url": "https://old.com"}
+            }
+        }
+        local_cfg = {"providers": {"deepseek": VALID_DEEPSEEK}}
+        result = _merge_configs(global_cfg, local_cfg)
+        assert (
+            result["providers"]["deepseek"]["base_url"] == "https://api.deepseek.com/v1"
+        )
+
+    def test_merged_has_both(self):
+        global_cfg = {"providers": {"provider_a": VALID_DEEPSEEK}}
+        local_cfg = {"providers": {"provider_b": VALID_MINIMAL}}
+        result = _merge_configs(global_cfg, local_cfg)
+        assert "provider_a" in result["providers"]
+        assert "provider_b" in result["providers"]
+
+
+class TestLoadProviderConfig:
+    def test_no_config_files(self, tmp_global_config, tmp_local_config):
+        config = load_provider_config()
+        assert config == {"providers": {}}
+
+    def test_load_global_only(self, tmp_global_config, tmp_local_config):
+        _write_json(tmp_global_config, {"providers": {"deepseek": VALID_DEEPSEEK}})
+        config = load_provider_config()
+        assert "deepseek" in config["providers"]
+
+    def test_load_local_only(self, tmp_global_config, tmp_local_config):
+        _write_json(tmp_local_config, {"providers": {"siliconflow": VALID_MINIMAL}})
+        config = load_provider_config()
+        assert "siliconflow" in config["providers"]
+
+    def test_local_overrides_global(self, tmp_global_config, tmp_local_config):
+        _write_json(
+            tmp_global_config,
+            {
+                "providers": {
+                    "deepseek": {"api_style": "openai", "base_url": "https://old.com"}
+                }
+            },
+        )
+        _write_json(tmp_local_config, {"providers": {"deepseek": VALID_DEEPSEEK}})
+        config = load_provider_config()
+        assert (
+            config["providers"]["deepseek"]["base_url"] == "https://api.deepseek.com/v1"
+        )
+
+
+class TestGetProvider:
+    def test_existing_provider(self, tmp_global_config, tmp_local_config):
+        _write_json(tmp_local_config, {"providers": {"deepseek": VALID_DEEPSEEK}})
+        result = get_provider("deepseek")
+        assert result == VALID_DEEPSEEK
+
+    def test_nonexistent_provider(self, tmp_global_config, tmp_local_config):
+        _write_json(tmp_local_config, {"providers": {"deepseek": VALID_DEEPSEEK}})
+        with pytest.raises(ValueError, match="not found in config"):
+            get_provider("nonexistent")
+
+    def test_empty_config(self, tmp_global_config, tmp_local_config):
+        with pytest.raises(ValueError, match="not found in config"):
+            get_provider("anything")
+
+
+class TestGetTranslatorClass:
+    def test_openai_style(self):
+        assert get_translator_class("openai") is ChatGPTAPI
+
+    def test_claude_style(self):
+        assert get_translator_class("claude") is Claude
+
+    def test_gemini_style(self):
+        assert get_translator_class("gemini") is Gemini
+
+    def test_qwen_style(self):
+        assert get_translator_class("qwen") is QwenTranslator
+
+    def test_unsupported_style(self):
+        with pytest.raises(ValueError, match="Unsupported api_style"):
+            get_translator_class("nonexistent")
+
+    def test_all_styles_mapped(self):
+        for style in SUPPORTED_API_STYLES:
+            cls = get_translator_class(style)
+            assert cls is not None


### PR DESCRIPTION
Introduce --provider/--api_key CLI args that load provider definitions from bbm_providers.json (~/.bbm/providers.json for global config). Supports any OpenAI-compatible API (DeepSeek, SiliconFlow, etc.) without modifying source code. Includes 28 unit tests and docs in both English and Chinese READMEs.