### PR TITLE
feat: add EPUB scan mode for discovering translatable tags

### DIFF
--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -282,7 +282,18 @@ def main():
         dest="translate_tags",
         type=str,
         default="p",
-        help="example --translate-tags p,blockquote",
+        help="CSS selectors for tags to translate, comma-separated. "
+        "Supports tag names (p), tag.class (div.Para), or mixed (p,div.Para,blockquote). "
+        "Use --scan to detect potentially untranslated tags first. "
+        "Example: --translate-tags p,div.Para",
+    )
+    parser.add_argument(
+        "--scan",
+        dest="scan",
+        action="store_true",
+        default=False,
+        help="Scan the EPUB for potentially untranslated text content and print a report. "
+        "Does not perform translation. Use this to discover which tags to add to --translate-tags.",
     )
     parser.add_argument(
         "--exclude-translate-tags",
@@ -456,6 +467,23 @@ So you are close to reaching the limit. You have to choose your own value, there
     if PROXY != "":
         os.environ["http_proxy"] = PROXY
         os.environ["https_proxy"] = PROXY
+
+    # --scan mode: only needs EPUB file, no translation model or API key
+    if options.scan:
+        book_type = options.book_name.split(".")[-1]
+        if book_type != "epub":
+            print("Error: --scan is only supported for EPUB files.")
+            exit(1)
+        from book_maker.loader.epub_loader import EPUBBookLoader
+        from ebooklib import epub
+
+        loader = object.__new__(EPUBBookLoader)
+        loader.origin_book = epub.read_epub(options.book_name)
+        loader.translate_tags = options.translate_tags or "p"
+        loader.exclude_filelist = options.exclude_filelist or ""
+        loader.only_filelist = options.only_filelist or ""
+        loader.scan_untranslated_tags()
+        exit(0)
 
     provider_cfg = None
     if options.provider:

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -24,6 +24,290 @@ from .helper import EPUBBookLoaderHelper, is_text_link, not_trans, shorter_resul
 
 
 class EPUBBookLoader(BaseBookLoader):
+    # Tags to exclude during --scan (structural + inline + container tags)
+    _SCAN_EXCLUDE_TAGS = frozenset(
+        {
+            "html",
+            "head",
+            "body",
+            "script",
+            "style",
+            "meta",
+            "link",
+            "title",
+            "nav",
+            "svg",
+            "math",
+            "img",
+            "br",
+            "hr",
+            "table",
+            "thead",
+            "tbody",
+            "tr",
+            "td",
+            "th",
+            "col",
+            "colgroup",
+            # Inline elements - should not be translated independently
+            "em",
+            "strong",
+            "b",
+            "i",
+            "u",
+            "span",
+            "a",
+            "sub",
+            "sup",
+            "code",
+            "kbd",
+            "var",
+            "samp",
+            "abbr",
+            "cite",
+            "q",
+            "small",
+            "mark",
+            "del",
+            "ins",
+            "dfn",
+            "ruby",
+            "rt",
+            "rp",
+            "bdo",
+            "wbr",
+            # Container elements - their text is the sum of children
+            "section",
+            "article",
+            "aside",
+            "header",
+            "footer",
+            "main",
+            "figure",
+            "figcaption",
+            "ol",
+            "ul",
+            "dl",
+            "dd",
+            "dt",
+        }
+    )
+
+    def _parse_translate_tags(self):
+        """Parse translate_tags into a CSS selector string.
+
+        Sets:
+            self._css_selector: CSS selector string for soup.select(), e.g. "p, div.Para"
+        """
+        specs = [s.strip() for s in self.translate_tags.split(",") if s.strip()]
+        self._css_selector = ", ".join(specs)
+
+    def _find_translatable_paragraphs(self, soup):
+        """Find all translatable paragraphs using CSS selector and handle nested structures.
+
+        Uses self._css_selector (set by _parse_translate_tags) to find paragraphs.
+        For paragraphs that contain nested translatable child tags (Type B),
+        extracts the outer direct text into a new <p> node inserted into the DOM.
+
+        Returns:
+            list: Paragraphs in DOM order, ready for translation.
+        """
+        p_list = soup.select(self._css_selector)
+
+        # Check for Type B: paragraphs with nested translatable children
+        extra_nodes = []
+        for p in list(p_list):  # iterate copy since we may modify DOM
+            if not self.has_nest_child(p, self._css_selector):
+                continue
+            # Type B: this paragraph has nested translatable children
+            # Extract direct text that is NOT inside nested translatable children
+            nested_matches = [m for m in p.select(self._css_selector) if m is not p]
+            nested_set = set(id(m) for m in nested_matches)
+            # Also include ancestors of nested matches (containers like blockquote)
+            nested_and_ancestors = set(nested_set)
+            for m in nested_matches:
+                if m is p:
+                    continue
+                for parent in m.parents:
+                    if parent is p:
+                        break
+                    nested_and_ancestors.add(id(parent))
+
+            direct_parts = []
+            first_nested = None
+            for child in p.children:
+                if isinstance(child, NavigableString):
+                    t = str(child).strip()
+                    if t:
+                        direct_parts.append(str(child))
+                elif isinstance(child, Tag):
+                    if id(child) in nested_and_ancestors:
+                        if first_nested is None:
+                            first_nested = child
+                    else:
+                        # Inline tags like <em>, <span> - part of outer text
+                        direct_parts.append(str(child))
+
+            direct_text = "".join(direct_parts).strip()
+            if not direct_text or self._is_special_text(direct_text):
+                continue
+
+            # Create a new <p> node with the direct text and insert it into DOM
+            new_p = soup.new_tag("p", attrs={"class": "_bbm_extracted"})
+            new_p.append(bs(direct_text, "html.parser"))
+            if first_nested is not None:
+                first_nested.insert_before(new_p)
+            else:
+                p.insert(0, new_p)
+            extra_nodes.append(new_p)
+
+        if extra_nodes:
+            # Re-select to include newly inserted nodes, maintaining DOM order
+            p_list = soup.select(self._css_selector)
+
+        return p_list
+
+    def scan_untranslated_tags(self):
+        """Scan EPUB for potentially untranslated text content.
+
+        Finds all tags containing substantial text that are not covered by
+        the current --translate-tags selector. Groups results by CSS selector
+        format (tag.class) and prints a report.
+        """
+        self._parse_translate_tags()
+        all_items = list(self.origin_book.get_items())
+
+        # Collect stats: {selector_str: {"count": int, "example": str}}
+        stats = {}
+
+        for item in all_items:
+            if item.get_type() != ITEM_DOCUMENT:
+                continue
+            if item.file_name in self.exclude_filelist.split(","):
+                continue
+            if self.only_filelist and item.file_name not in self.only_filelist.split(
+                ","
+            ):
+                continue
+
+            content = item.content
+            soup = bs(content, "html.parser")
+
+            # Find already-covered paragraphs
+            covered = soup.select(self._css_selector) if self._css_selector else []
+            covered_set = set(id(p) for p in covered)
+
+            # Build set of all descendants of covered paragraphs (to exclude children)
+            covered_descendants = set()
+            for p in covered:
+                for desc in p.descendants:
+                    covered_descendants.add(id(desc))
+
+            # Scan all tags
+            for tag in soup.find_all(True):
+                if tag.name in self._SCAN_EXCLUDE_TAGS:
+                    continue
+                # Skip if this tag is already covered
+                if id(tag) in covered_set:
+                    continue
+                # Skip if this tag is a descendant of a covered paragraph
+                if id(tag) in covered_descendants:
+                    continue
+
+                text = tag.get_text().strip()
+                if len(text) < 20:
+                    continue
+                if self._is_special_text(text):
+                    continue
+
+                # Check if this tag's text is fully contained in any covered paragraph
+                is_contained = False
+                for p in covered:
+                    if text in p.get_text():
+                        is_contained = True
+                        break
+                if is_contained:
+                    continue
+
+                # Build CSS selector key
+                classes = tag.get("class", [])
+                if classes:
+                    selector_key = f"{tag.name}.{classes[0]}"
+                else:
+                    selector_key = tag.name
+
+                if selector_key not in stats:
+                    stats[selector_key] = {"count": 0, "example": text[:80]}
+                stats[selector_key]["count"] += 1
+
+        # Print report
+        if not stats:
+            print("No potentially untranslated content detected.")
+            return ""
+
+        sorted_items = sorted(stats.items(), key=lambda x: -x[1]["count"])
+        current_tags = self.translate_tags
+
+        # Build choices for interactive selection
+        choices = []
+        for selector, info in sorted_items:
+            label = f"{selector:25s}  {info['count']:4d} paragraphs  \"{info['example'][:45]}...\""
+            choices.append((selector, label))
+
+        selected = self._interactive_checkbox(
+            title=f"Potentially untranslated content detected. "
+            f'Current --translate-tags: "{current_tags}"',
+            choices=choices,
+        )
+
+        if not selected:
+            print("No tags selected.")
+            return ""
+
+        combined = ",".join([current_tags] + selected)
+        print()
+        print("Selected tags:")
+        for sel in selected:
+            info = stats[sel]
+            print(f"  + {sel} ({info['count']} paragraphs)")
+        print()
+        print(f'Combined --translate-tags: "{combined}"')
+        print()
+        print("Command to use:")
+        print(f'  --translate-tags "{combined}"')
+        print()
+        return combined
+
+    @staticmethod
+    def _interactive_checkbox(title, choices):
+        """Terminal checkbox widget using InquirerPy.
+
+        Args:
+            title: Header text displayed as the prompt message.
+            choices: List of (value, label) tuples.
+
+        Returns:
+            List of selected values, or empty list if cancelled.
+        """
+        from InquirerPy import inquirer
+        from InquirerPy.base.control import Choice
+
+        if not choices:
+            return []
+
+        inq_choices = [Choice(value=value, name=label) for value, label in choices]
+
+        try:
+            selected = inquirer.checkbox(
+                message=title,
+                choices=inq_choices,
+                instruction="(Space: toggle, Tab: toggle all, Enter: confirm)",
+            ).execute()
+        except (KeyboardInterrupt, EOFError):
+            return []
+
+        return selected if selected else []
+
     def __init__(
         self,
         epub_name,
@@ -212,19 +496,20 @@ class EPUBBookLoader(BaseBookLoader):
         return fixed_toc
 
     def _extract_paragraph(self, p):
-        for p_exclude in self.exclude_translate_tags.split(","):
-            # for issue #280
-            if type(p) is NavigableString:
-                continue
-            for pt in p.find_all(p_exclude):
-                pt.extract()
-        # Exclude content within specified tags from translation (e.g., code, pre)
-        exclude_tags_list = [t for t in self.exclude_translate_tags.split(",") if t]
-        for tag_name in exclude_tags_list:
-            if type(p) is NavigableString:
+        if type(p) is NavigableString:
+            return p
+        # Exclude content within specified tags from translation (e.g., sup, code, pre)
+        for tag_name in self.exclude_translate_tags.split(","):
+            tag_name = tag_name.strip()
+            if not tag_name:
                 continue
             for pt in p.find_all(tag_name):
                 pt.extract()
+        # For div-type paragraphs (e.g., div.Para), remove nested div children
+        # (Equation, MediaObject, etc.) to avoid translating formula alt text
+        if p.name == "div":
+            for nested_div in p.find_all("div"):
+                nested_div.extract()
         return p
 
     def _is_content_only_excluded_tags(self, p):
@@ -251,7 +536,7 @@ class EPUBBookLoader(BaseBookLoader):
         remaining_text = temp_p.get_text().strip()
         return not remaining_text or self._is_special_text(remaining_text)
 
-    def _count_translatable_paragraphs(self, items, trans_taglist):
+    def _count_translatable_paragraphs(self, items):
         """Count paragraphs that actually need translation (excluding special content)."""
         count = 0
         for i in items:
@@ -264,7 +549,7 @@ class EPUBBookLoader(BaseBookLoader):
 
             content = i.content
             soup = bs(content, "html.parser")
-            p_list = soup.findAll(trans_taglist)
+            p_list = self._find_translatable_paragraphs(soup)
 
             if self.allow_navigable_strings:
                 p_list.extend(soup.findAll(text=True))
@@ -616,7 +901,7 @@ class EPUBBookLoader(BaseBookLoader):
 
         return matching_items
 
-    def retranslate_book(self, index, p_to_save_len, pbar, trans_taglist, retranslate):
+    def retranslate_book(self, index, p_to_save_len, pbar, retranslate):
         complete_book_name = retranslate[0]
         fixname = retranslate[1]
         fixstart = retranslate[2]
@@ -650,8 +935,8 @@ class EPUBBookLoader(BaseBookLoader):
         soup_complete = bs(content_complete, "html.parser")
         soup_ori = bs(content_ori, "html.parser")
 
-        p_list_complete = soup_complete.findAll(trans_taglist)
-        p_list_ori = soup_ori.findAll(trans_taglist)
+        p_list_complete = soup_complete.select(self._css_selector)
+        p_list_ori = soup_ori.select(self._css_selector)
 
         target = None
         tagl = []
@@ -704,23 +989,20 @@ class EPUBBookLoader(BaseBookLoader):
             p_to_save_len,
             pbar,
             new_book,
-            trans_taglist,
             fixstart,
             fixend,
         )
         epub.write_epub(f"{name_fix}", new_book, {})
 
-    def has_nest_child(self, element, trans_taglist):
+    def has_nest_child(self, element, css_selector):
+        """Check if element has any descendant matching the CSS selector."""
         if isinstance(element, Tag):
-            for child in element.children:
-                if child.name in trans_taglist:
-                    return True
-                if self.has_nest_child(child, trans_taglist):
-                    return True
+            matches = element.select(css_selector)
+            return any(m is not element for m in matches)
         return False
 
-    def filter_nest_list(self, p_list, trans_taglist):
-        filtered_list = [p for p in p_list if not self.has_nest_child(p, trans_taglist)]
+    def filter_nest_list(self, p_list, css_selector):
+        filtered_list = [p for p in p_list if not self.has_nest_child(p, css_selector)]
         return filtered_list
 
     def process_item(
@@ -730,7 +1012,6 @@ class EPUBBookLoader(BaseBookLoader):
         p_to_save_len,
         pbar,
         new_book,
-        trans_taglist,
         fixstart=None,
         fixend=None,
     ):
@@ -749,9 +1030,9 @@ class EPUBBookLoader(BaseBookLoader):
 
         content = item.content
         soup = bs(content, "html.parser")
-        p_list = soup.findAll(trans_taglist)
+        p_list = self._find_translatable_paragraphs(soup)
 
-        p_list = self.filter_nest_list(p_list, trans_taglist)
+        p_list = self.filter_nest_list(p_list, self._css_selector)
 
         if self.retranslate:
             new_p_list = []
@@ -874,7 +1155,7 @@ class EPUBBookLoader(BaseBookLoader):
 
     def _process_chapter_parallel(self, chapter_data):
         """Process a single chapter in parallel mode with proper accumulated_num handling."""
-        item, trans_taglist, p_to_save_len = chapter_data
+        item, p_to_save_len = chapter_data
         chapter_result = {
             "item": item,
             "processed_content": None,
@@ -889,8 +1170,8 @@ class EPUBBookLoader(BaseBookLoader):
 
             content = item.content
             soup = bs(content, "html.parser")
-            p_list = soup.findAll(trans_taglist)
-            p_list = self.filter_nest_list(p_list, trans_taglist)
+            p_list = self._find_translatable_paragraphs(soup)
+            p_list = self.filter_nest_list(p_list, self._css_selector)
 
             if self.allow_navigable_strings:
                 p_list.extend(soup.findAll(text=True))
@@ -1164,10 +1445,10 @@ class EPUBBookLoader(BaseBookLoader):
         self.batch_init_then_wait()
         new_book = self._make_new_book(self.origin_book)
         all_items = list(self.origin_book.get_items())
-        trans_taglist = self.translate_tags.split(",")
+        self._parse_translate_tags()
 
         # Count only paragraphs that actually need translation
-        all_p_length = self._count_translatable_paragraphs(all_items, trans_taglist)
+        all_p_length = self._count_translatable_paragraphs(all_items)
 
         # Use leave=False in test mode to prevent duplicate progress bar display
         pbar = tqdm(
@@ -1179,9 +1460,7 @@ class EPUBBookLoader(BaseBookLoader):
         p_to_save_len = len(self.p_to_save)
         try:
             if self.retranslate:
-                self.retranslate_book(
-                    index, p_to_save_len, pbar, trans_taglist, self.retranslate
-                )
+                self.retranslate_book(index, p_to_save_len, pbar, self.retranslate)
                 exit(0)
             # Add the things that don't need to be translated first, so that you can see the img after the interruption
             for item in self.origin_book.get_items():
@@ -1221,9 +1500,7 @@ class EPUBBookLoader(BaseBookLoader):
                     total=len(document_items), desc="Chapters", unit="ch"
                 )
 
-                chapter_data_list = [
-                    (item, trans_taglist, p_to_save_len) for item in document_items
-                ]
+                chapter_data_list = [(item, p_to_save_len) for item in document_items]
 
                 with ThreadPoolExecutor(max_workers=effective_workers) as executor:
                     future_to_item = {
@@ -1281,7 +1558,7 @@ class EPUBBookLoader(BaseBookLoader):
                         continue
 
                     index = self.process_item(
-                        item, index, p_to_save_len, pbar, new_book, trans_taglist
+                        item, index, p_to_save_len, pbar, new_book
                     )
 
                     # Check for fatal error after processing
@@ -1338,14 +1615,13 @@ class EPUBBookLoader(BaseBookLoader):
         origin_book_temp = epub.read_epub(self.epub_name)
         new_temp_book = self._make_new_book(origin_book_temp)
         p_to_save_len = len(self.p_to_save)
-        trans_taglist = self.translate_tags.split(",")
         index = 0
         try:
             for item in origin_book_temp.get_items():
                 if item.get_type() == ITEM_DOCUMENT:
                     content = item.content
                     soup = bs(content, "html.parser")
-                    p_list = soup.findAll(trans_taglist)
+                    p_list = self._find_translatable_paragraphs(soup)
                     if self.allow_navigable_strings:
                         p_list.extend(soup.findAll(text=True))
                     for p in p_list:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "groq>=0.5.0",
     "promptdown>=0.9.0",
     "PyMuPDF",
+    "InquirerPy",
 ]
 
 [project.scripts]

--- a/tests/test_translate_tags.py
+++ b/tests/test_translate_tags.py
@@ -1,0 +1,233 @@
+"""Unit tests for enhanced --translate-tags CSS selector support and --scan mode."""
+
+import pytest
+from copy import copy
+from bs4 import BeautifulSoup as bs
+from bs4.element import NavigableString, Tag
+from unittest.mock import MagicMock, patch
+
+
+def make_loader():
+    """Create a minimal EPUBBookLoader-like object for testing."""
+    from book_maker.loader.epub_loader import EPUBBookLoader
+
+    # We can't easily instantiate the full loader (needs epub file),
+    # so we test the methods directly by creating a mock-like object
+    loader = object.__new__(EPUBBookLoader)
+    loader.translate_tags = "p"
+    loader.exclude_translate_tags = "sup,code"
+    loader.allow_navigable_strings = False
+    return loader
+
+
+class TestParseTranslateTags:
+    def test_simple_tag(self):
+        loader = make_loader()
+        loader.translate_tags = "p"
+        loader._parse_translate_tags()
+        assert loader._css_selector == "p"
+
+    def test_multiple_tags(self):
+        loader = make_loader()
+        loader.translate_tags = "p,blockquote"
+        loader._parse_translate_tags()
+        assert loader._css_selector == "p, blockquote"
+
+    def test_css_selector_with_class(self):
+        loader = make_loader()
+        loader.translate_tags = "p,div.Para"
+        loader._parse_translate_tags()
+        assert loader._css_selector == "p, div.Para"
+
+    def test_multiple_selectors_with_classes(self):
+        loader = make_loader()
+        loader.translate_tags = "p,div.Para,div.SimplePara"
+        loader._parse_translate_tags()
+        assert loader._css_selector == "p, div.Para, div.SimplePara"
+
+    def test_whitespace_handling(self):
+        loader = make_loader()
+        loader.translate_tags = " p , div.Para "
+        loader._parse_translate_tags()
+        assert loader._css_selector == "p, div.Para"
+
+
+class TestFindTranslatableParagraphs:
+    def test_simple_p_only(self):
+        """With default 'p' selector, only <p> tags are found."""
+        loader = make_loader()
+        loader.translate_tags = "p"
+        loader._parse_translate_tags()
+
+        html = "<div><p>Hello world</p><div class='Para'>Missed text</div></div>"
+        soup = bs(html, "html.parser")
+        result = loader._find_translatable_paragraphs(soup)
+
+        texts = [p.get_text().strip() for p in result]
+        assert "Hello world" in texts
+        assert "Missed text" not in texts
+
+    def test_div_para_type_a(self):
+        """Type A: div.Para without nested <p> is found when selector includes div.Para."""
+        loader = make_loader()
+        loader.translate_tags = "p,div.Para"
+        loader._parse_translate_tags()
+
+        html = '<div><p>Normal paragraph</p><div class="Para">This is a semantic paragraph</div></div>'
+        soup = bs(html, "html.parser")
+        result = loader._find_translatable_paragraphs(soup)
+
+        texts = [p.get_text().strip() for p in result]
+        assert "Normal paragraph" in texts
+        assert "This is a semantic paragraph" in texts
+
+    def test_div_para_type_b(self):
+        """Type B: div.Para with nested <p> - outer direct text extracted as new <p>."""
+        loader = make_loader()
+        loader.translate_tags = "p,div.Para"
+        loader._parse_translate_tags()
+
+        html = """
+        <div class="Para" id="Par5">
+          The definition is as follows:
+          <blockquote>
+            <p>A program is in SSA form if each variable is assigned exactly once.</p>
+          </blockquote>
+        </div>
+        """
+        soup = bs(html, "html.parser")
+        result = loader._find_translatable_paragraphs(soup)
+
+        texts = [p.get_text().strip() for p in result]
+        # The inner <p> should be found
+        assert any("A program is in SSA form" in t for t in texts)
+        # The outer direct text should be extracted as a new <p>
+        assert any("The definition is as follows:" in t for t in texts)
+
+    def test_type_b_no_duplicate(self):
+        """Type B: inner <p> text should NOT appear in the extracted outer text."""
+        loader = make_loader()
+        loader.translate_tags = "p,div.Para"
+        loader._parse_translate_tags()
+
+        html = """
+        <div class="Para">
+          Outer text here.
+          <blockquote><p>Inner paragraph text.</p></blockquote>
+        </div>
+        """
+        soup = bs(html, "html.parser")
+        result = loader._find_translatable_paragraphs(soup)
+
+        # Find the extracted node
+        extracted = [p for p in result if p.get("class") == ["_bbm_extracted"]]
+        assert len(extracted) == 1
+        assert "Inner paragraph text" not in extracted[0].get_text()
+        assert "Outer text here" in extracted[0].get_text()
+
+    def test_backward_compat_no_extra(self):
+        """When using just 'p', behavior is identical to original."""
+        loader = make_loader()
+        loader.translate_tags = "p"
+        loader._parse_translate_tags()
+
+        html = "<div><p>One</p><p>Two</p><div class='Para'>Three</div></div>"
+        soup = bs(html, "html.parser")
+        result = loader._find_translatable_paragraphs(soup)
+
+        texts = [p.get_text().strip() for p in result]
+        assert texts == ["One", "Two"]
+
+    def test_dom_order(self):
+        """Results should be in DOM order."""
+        loader = make_loader()
+        loader.translate_tags = "p,div.Para"
+        loader._parse_translate_tags()
+
+        html = '<div><div class="Para">First</div><p>Second</p><div class="Para">Third</div></div>'
+        soup = bs(html, "html.parser")
+        result = loader._find_translatable_paragraphs(soup)
+
+        texts = [p.get_text().strip() for p in result]
+        assert texts == ["First", "Second", "Third"]
+
+
+class TestExtractParagraph:
+    def test_div_removes_nested_divs(self):
+        """For div-type paragraphs, nested div children are removed."""
+        loader = make_loader()
+
+        html = """
+        <div class="Para">
+          Some text here.
+          <div class="Equation"><img alt="x = y + 1"/></div>
+          More text.
+        </div>
+        """
+        soup = bs(html, "html.parser")
+        div_para = soup.find("div", class_="Para")
+        result = loader._extract_paragraph(copy(div_para))
+
+        text = result.get_text().strip()
+        assert "Some text here" in text
+        assert "More text" in text
+        # Equation div should be removed
+        assert result.find("div", class_="Equation") is None
+
+    def test_p_tag_unchanged(self):
+        """For <p> tags, no div removal happens."""
+        loader = make_loader()
+
+        html = "<p>Hello <em>world</em></p>"
+        soup = bs(html, "html.parser")
+        p = soup.find("p")
+        result = loader._extract_paragraph(copy(p))
+
+        assert result.get_text().strip() == "Hello world"
+
+
+class TestFilterNestList:
+    def test_basic_filter(self):
+        """Paragraphs with nested translatable children are filtered out."""
+        loader = make_loader()
+
+        html = "<div><p>Outer <p>Inner</p></p><p>Simple</p></div>"
+        soup = bs(html, "html.parser")
+        p_list = soup.find_all("p")
+        result = loader.filter_nest_list(p_list, "p")
+
+        texts = [p.get_text().strip() for p in result]
+        # Only "Inner" and "Simple" should remain (outer filtered)
+        assert "Simple" in texts
+
+    def test_extracted_p_not_filtered(self):
+        """Extracted _bbm_extracted <p> nodes have no nesting, should not be filtered."""
+        loader = make_loader()
+
+        html = '<p class="_bbm_extracted">Extracted text</p><p>Normal</p>'
+        soup = bs(html, "html.parser")
+        p_list = soup.find_all("p")
+        result = loader.filter_nest_list(p_list, "p")
+
+        texts = [p.get_text().strip() for p in result]
+        assert "Extracted text" in texts
+        assert "Normal" in texts
+
+    def test_css_selector_precision(self):
+        """filter_nest_list with CSS selector 'p, div.Para' should NOT filter
+        a div.Para that contains div.Equation (non-matching nested div)."""
+        loader = make_loader()
+
+        html = """
+        <div class="Para">
+          Some text.
+          <div class="Equation">x = 1</div>
+        </div>
+        """
+        soup = bs(html, "html.parser")
+        div_para = soup.find_all("div", class_="Para")
+        result = loader.filter_nest_list(div_para, "p, div.Para")
+
+        # div.Equation does NOT match "p, div.Para", so div.Para should NOT be filtered
+        assert len(result) == 1
+        assert "Some text" in result[0].get_text()


### PR DESCRIPTION

  ## Summary

  - Add `--scan` mode for EPUB files to detect potentially untranslated text content without running translation
  - Enhance `--translate-tags` to support CSS selectors such as `p,div.Para`
  - Add interactive tag selection using `InquirerPy` and print the combined `--translate-tags` command
  - Rework EPUB paragraph discovery so custom selectors are used consistently during counting, translation, resume/temp-save, and parallel processing


  ## Details

  This helps users discover EPUB content stored outside normal `<p>` tags before starting a full translation run.

  Examples of supported `--translate-tags` values:

  ```bash
  --translate-tags "p"
  --translate-tags "p,blockquote"
  --translate-tags "p,div.Para"
  --translate-tags "p,div.Para,div.SimplePara"
  --translate-tags "p,div.Para,blockquote"

  Common cases this can cover:

  - p: regular EPUB paragraphs
  - blockquote: quoted blocks that should be translated as standalone text
  - div.Para: EPUBs that encode paragraphs as <div class="Para">
  - div.SimplePara: EPUBs that use alternate paragraph classes
  - mixed selectors: books containing several paragraph-like structures

  Example scan command:

  bilingual_book_maker --book_name book.epub --scan

  Example translation command after scan:

  bilingual_book_maker --book_name book.epub --translate-tags "p,div.Para,blockquote"

  The scan respects:

  - --translate-tags
  - --exclude_filelist
  - --only_filelist

  ## Testing

  - Added unit coverage for CSS selector parsing
  - Added coverage for div.Para paragraph discovery
  - Added coverage for nested paragraph extraction behavior
  - Added coverage for preserving existing <p> behavior