### PR TITLE
fix: Gemini model lists are stale, causing StopIteration crash on default usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 * Gemini
 
   Support Google [Gemini](https://aistudio.google.com/app/apikey) model, use `--model gemini` for Gemini Flash or `--model geminipro` for Gemini Pro.
-  If you want to use a specific model alias with Gemini (eg `gemini-1.5-flash-002` or `gemini-1.5-flash-8b-exp-0924`), you can use `--model gemini --model_list gemini-1.5-flash-002,gemini-1.5-flash-8b-exp-0924`. `--model_list` takes a comma-separated list of model aliases.
+  If you want to use a specific model alias with Gemini (eg `gemini-2.5-flash` or `gemini-2.0-flash`), you can use `--model gemini --model_list gemini-2.5-flash,gemini-2.0-flash`. `--model_list` takes a comma-separated list of model aliases.
 
   ```shell
   python3 make_book.py --book_name test_books/animal_farm.epub --model gemini --gemini_key ${gemini_key}
@@ -375,7 +375,7 @@ python3 make_book.py --book_name test_books/animal_farm.epub --gemini_key ${gemi
 python3 make_book.py --book_name test_books/animal_farm.epub --openai_key ${openai_key} --parallel-workers 4
 
 # Use a specific list of Gemini model aliases
-python3 make_book.py --book_name test_books/animal_farm.epub --gemini_key ${gemini_key} --model gemini --model_list gemini-1.5-flash-002,gemini-1.5-flash-8b-exp-0924
+python3 make_book.py --book_name test_books/animal_farm.epub --gemini_key ${gemini_key} --model gemini --model_list gemini-2.5-flash,gemini-2.0-flash
 
 # Set env OPENAI_API_KEY to ignore option --openai_key
 export OPENAI_API_KEY=${your_api_key}

--- a/book_maker/translator/gemini_translator.py
+++ b/book_maker/translator/gemini_translator.py
@@ -83,19 +83,18 @@ PROMPT_ENV_MAP = {
 }
 
 GEMINIPRO_MODEL_LIST = [
-    "gemini-1.5-pro",
-    "gemini-1.5-pro-latest",
-    "gemini-1.5-pro-001",
-    "gemini-1.5-pro-002",
+    "gemini-pro-latest",
+    "gemini-2.5-pro",
+    "gemini-3-pro-preview",
 ]
 
 GEMINIFLASH_MODEL_LIST = [
-    "gemini-1.5-flash",
-    "gemini-1.5-flash-latest",
-    "gemini-1.5-flash-001",
-    "gemini-1.5-flash-002",
-    "gemini-2.0-flash-exp",
-    "gemini-2.5-flash-preview-04-17",
+    "gemini-flash-latest",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash",
+    "gemini-2.5-flash-lite",
+    "gemini-2.0-flash-001",
+    "gemini-flash-lite-latest",
 ]
 
 
@@ -296,6 +295,11 @@ class Gemini(Base):
             list(set(available_models) & set(allowed_models)),
             key=allowed_models.index,
         )
+        if not model_list:
+            raise ValueError(
+                f"None of the expected models {allowed_models} are available "
+                f"for this API key. Available models: {available_models}"
+            )
         print(f"Using model list {model_list}")
         self.model_list = cycle(model_list)
         self.rotate_model()


### PR DESCRIPTION
## Problem
Running the documented default command crashes immediately:

    python make_book.py --book_name book.epub --model gemini --gemini_key $KEY

    Using model list []
    Traceback (most recent call last):
      ...
      File ".../gemini_translator.py", line 191, in rotate_model
        self.model = next(self.model_list)
                     ~~~~^^^^^^^^^^^^^^^^^
    StopIteration

This is the same root cause as #467 and #457.

## Root cause
`GEMINIFLASH_MODEL_LIST` / `GEMINIPRO_MODEL_LIST` hardcode Gemini
1.5-era model names plus two now-dead preview IDs (`gemini-2.0-flash-exp`,
`gemini-2.5-flash-preview-04-17`). None of these exist in the Gemini API
anymore, so `set_models()` intersects the hardcoded list against the
user's real available models and gets `[]`. `cycle([])` is a valid
iterator that immediately raises `StopIteration` on the first `next()`.

## Fix
- Updated both lists to current model names, verified live against the
  Gemini API with a real key.
- Added a clear `ValueError` when the filtered list is empty, so the
  next time Google deprecates a model name, users get an actionable
  error instead of a bare `StopIteration`.
- Updated two README examples that referenced the same dead 1.5 model IDs.

## Testing
- `black --check` passes on the changed file.
- Manually instantiated `Gemini(...).set_geminiflash_models()` /
  `set_geminipro_models()` against a live key — confirms
  `gemini-flash-latest` / `gemini-pro-latest` are selected correctly.