### PR TITLE
Add bilingual PDF output layouts

### DIFF
--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -336,6 +336,13 @@ So you are close to reaching the limit. You have to choose your own value, there
         help="how many lines will be translated by aggregated translation(This options currently only applies to txt files)",
     )
     parser.add_argument(
+        "--pdf_layout",
+        dest="pdf_layout",
+        choices=["none", "top-bottom", "side-by-side", "all"],
+        default="none",
+        help="PDF output layout for PDF inputs: top-bottom, side-by-side, all, or none",
+    )
+    parser.add_argument(
         "--retranslate",
         dest="retranslate",
         nargs=4,
@@ -565,6 +572,10 @@ So you are close to reaching the limit. You have to choose your own value, there
     if options.provider and provider_cfg and not model_api_base:
         model_api_base = provider_cfg.get("base_url")
 
+    loader_kwargs = {}
+    if book_type == "pdf":
+        loader_kwargs["pdf_layout"] = options.pdf_layout
+
     e = book_loader(
         options.book_name,
         translate_model,
@@ -581,6 +592,7 @@ So you are close to reaching the limit. You have to choose your own value, there
         temperature=options.temperature,
         source_lang=options.source_lang,
         parallel_workers=options.parallel_workers,
+        **loader_kwargs,
     )
     # Parse and set extra_body if provided
     if options.extra_body:

--- a/book_maker/loader/pdf_loader.py
+++ b/book_maker/loader/pdf_loader.py
@@ -11,7 +11,6 @@ import fitz
 
 from ebooklib import epub
 
-
 PDF_LAYOUTS = ("top-bottom", "side-by-side")
 
 

--- a/book_maker/loader/pdf_loader.py
+++ b/book_maker/loader/pdf_loader.py
@@ -12,6 +12,159 @@ import fitz
 from ebooklib import epub
 
 
+PDF_LAYOUTS = ("top-bottom", "side-by-side")
+
+
+def create_bilingual_pdf(pairs, out_path, title, layout="top-bottom"):
+    try:
+        from reportlab.lib import colors
+        from reportlab.lib.pagesizes import A4
+        from reportlab.pdfbase import pdfmetrics
+        from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+        from reportlab.pdfbase.ttfonts import TTFont
+        from reportlab.pdfgen import canvas
+    except Exception as e:
+        print(f"pdf creation skipped: install reportlab first ({e})")
+        return False
+
+    if layout not in PDF_LAYOUTS:
+        raise ValueError(f"unsupported pdf layout: {layout}")
+
+    font = "Helvetica"
+    ttf_path = Path("/System/Library/Fonts/Supplemental/Arial Unicode.ttf")
+    try:
+        if ttf_path.exists():
+            font = "BBMArialUnicode"
+            if font not in pdfmetrics.getRegisteredFontNames():
+                pdfmetrics.registerFont(TTFont(font, str(ttf_path)))
+        else:
+            font = "STSong-Light"
+            if font not in pdfmetrics.getRegisteredFontNames():
+                pdfmetrics.registerFont(UnicodeCIDFont(font))
+    except Exception:
+        font = "Helvetica"
+
+    page_w, page_h = A4
+    left = right = 46
+    top = 52
+    bottom = 46
+    font_size = 9.5
+    label_size = 8
+    leading = 13
+    max_w = page_w - left - right
+    col_gap = 18
+    col_w = (max_w - col_gap) / 2
+    width_cache = {}
+
+    def width(text, size=font_size):
+        key = (text, size)
+        if key not in width_cache:
+            width_cache[key] = pdfmetrics.stringWidth(text, font, size)
+        return width_cache[key]
+
+    def wrap_line(line, line_w):
+        line = line.replace("\t", "    ").rstrip()
+        if not line:
+            return [""]
+        out, cur, cur_w = [], [], 0.0
+        for ch in line:
+            ch_w = width(ch)
+            if cur and cur_w + ch_w > line_w:
+                out.append("".join(cur).rstrip())
+                cur = [] if ch == " " else [ch]
+                cur_w = 0.0 if ch == " " else ch_w
+            else:
+                cur.append(ch)
+                cur_w += ch_w
+        if cur:
+            out.append("".join(cur).rstrip())
+        return out or [""]
+
+    def wrap_text(text, line_w):
+        lines = []
+        for raw in str(text or "").splitlines() or [""]:
+            lines.extend(wrap_line(raw, line_w))
+        return lines
+
+    c = canvas.Canvas(str(out_path), pagesize=A4)
+    c.setTitle(title)
+    page_no = 0
+
+    def new_page():
+        nonlocal page_no, y
+        if page_no:
+            c.showPage()
+        page_no += 1
+        c.setStrokeColor(colors.HexColor("#d9d9d9"))
+        c.setLineWidth(0.4)
+        c.line(left, page_h - 36, page_w - right, page_h - 36)
+        c.line(left, 34, page_w - right, 34)
+        c.setFillColor(colors.HexColor("#666666"))
+        c.setFont(font, 8)
+        header = title
+        while width(header, 8) > max_w:
+            header = header[:-4] + "..."
+        c.drawString(left, page_h - 28, header)
+        c.drawCentredString(page_w / 2, 22, str(page_no))
+        c.setFillColor(colors.black)
+        c.setFont(font, font_size)
+        y = page_h - top
+
+    def ensure(lines=1):
+        if y - lines * leading < bottom:
+            new_page()
+
+    def draw_label(text, x):
+        c.setFillColor(colors.HexColor("#666666"))
+        c.setFont(font, label_size)
+        c.drawString(x, y, text)
+        c.setFillColor(colors.black)
+        c.setFont(font, font_size)
+
+    y = page_h - top
+    new_page()
+
+    for original, translated in pairs:
+        if layout == "top-bottom":
+            for label, text in (("Original", original), ("Translation", translated)):
+                ensure(2)
+                draw_label(label, left)
+                y -= leading
+                for line in wrap_text(text, max_w):
+                    ensure()
+                    if line:
+                        c.drawString(left, y, line)
+                    y -= leading
+                y -= 4
+            ensure()
+            c.setStrokeColor(colors.HexColor("#eeeeee"))
+            c.line(left, y + 4, page_w - right, y + 4)
+            y -= 4
+            continue
+
+        original_lines = wrap_text(original, col_w)
+        translated_lines = wrap_text(translated, col_w)
+        row_count = max(len(original_lines), len(translated_lines))
+        ensure(2)
+        draw_label("Original", left)
+        draw_label("Translation", left + col_w + col_gap)
+        y -= leading
+        for i in range(row_count):
+            ensure()
+            if i < len(original_lines) and original_lines[i]:
+                c.drawString(left, y, original_lines[i])
+            if i < len(translated_lines) and translated_lines[i]:
+                c.drawString(left + col_w + col_gap, y, translated_lines[i])
+            y -= leading
+        ensure()
+        c.setStrokeColor(colors.HexColor("#eeeeee"))
+        c.line(left, y + 4, page_w - right, y + 4)
+        y -= 6
+
+    c.save()
+    return True
+
+
 class PDFBookLoader(BaseBookLoader):
     def __init__(
         self,
@@ -30,6 +183,7 @@ class PDFBookLoader(BaseBookLoader):
         temperature=1.0,
         source_lang="auto",
         parallel_workers=1,
+        pdf_layout="none",
     ) -> None:
         if fitz is None:
             raise Exception("PyMuPDF (fitz) is required to use PDF loader")
@@ -51,6 +205,7 @@ class PDFBookLoader(BaseBookLoader):
         self.batch_size = 10
         self.single_translate = single_translate
         self.parallel_workers = max(1, parallel_workers)
+        self.pdf_layout = pdf_layout
 
         try:
             doc = fitz.open(self.pdf_name)
@@ -158,6 +313,31 @@ class PDFBookLoader(BaseBookLoader):
             print(f"create epub failed: {e}")
             return False
 
+    def _try_create_pdfs(self):
+        if self.pdf_layout == "none":
+            return
+
+        layouts = PDF_LAYOUTS if self.pdf_layout == "all" else (self.pdf_layout,)
+        if self.single_translate:
+            pairs = [("", translated) for translated in self.bilingual_result]
+        else:
+            pairs = []
+            for i in range(0, len(self.bilingual_result), 2):
+                translated = (
+                    self.bilingual_result[i + 1]
+                    if i + 1 < len(self.bilingual_result)
+                    else ""
+                )
+                pairs.append((self.bilingual_result[i], translated))
+
+        for layout in layouts:
+            out_path = (
+                Path(self.pdf_name).parent
+                / f"{Path(self.pdf_name).stem}_bilingual_{layout}.pdf"
+            )
+            if create_bilingual_pdf(pairs, out_path, Path(self.pdf_name).stem, layout):
+                print(f"created pdf: {out_path.name}")
+
     def make_bilingual_book(self):
         index = 0
         p_to_save_len = len(self.p_to_save)
@@ -203,6 +383,7 @@ class PDFBookLoader(BaseBookLoader):
                 print(
                     "epub creation skipped or failed; bilingual text saved to txt fallback"
                 )
+            self._try_create_pdfs()
 
         except (KeyboardInterrupt, Exception) as e:
             print(e)

--- a/book_maker/translator/qwen_translator.py
+++ b/book_maker/translator/qwen_translator.py
@@ -98,6 +98,8 @@ class QwenTranslator(Base):
         self.context_list = []
         self.context_translated_list = []
         self.context_paragraph_limit = context_paragraph_limit
+        self.request_interval = float(kwargs.get("request_interval", 1.2))
+        self._last_request_at = 0.0
 
         print("[bold blue]Qwen Translator initialized:[/bold blue]")
         print(f"  Model: {self.model}")
@@ -164,12 +166,26 @@ class QwenTranslator(Base):
             self.context_list.pop(0)
             self.context_translated_list.pop(0)
 
+    @staticmethod
+    def _is_rate_limit_error(error):
+        message = str(error)
+        return "429" in message or "limit_requests" in message
+
+    def _pace_request(self):
+        if self.request_interval <= 0:
+            return
+
+        wait_time = self.request_interval - (time.time() - self._last_request_at)
+        if wait_time > 0:
+            time.sleep(wait_time)
+        self._last_request_at = time.time()
+
     def translate(self, text):
         """Main translation method"""
         start_time = time.time()
 
         attempt_count = 0
-        max_attempts = 3
+        max_attempts = 6
         t_text = ""
 
         while attempt_count < max_attempts:
@@ -183,6 +199,7 @@ class QwenTranslator(Base):
                 translation_options = self._create_translation_options()
 
                 # Make API request
+                self._pace_request()
                 completion = self.client.chat.completions.create(
                     model=self.model,
                     messages=messages,
@@ -203,17 +220,20 @@ class QwenTranslator(Base):
 
             except Exception as e:
                 attempt_count += 1
+                is_rate_limit = self._is_rate_limit_error(e)
                 print(
                     f"[red]Translation attempt {attempt_count} failed: {str(e)}[/red]"
                 )
 
                 if attempt_count >= max_attempts:
+                    if is_rate_limit:
+                        raise
                     print(
                         f"[red]Translation failed after {max_attempts} attempts[/red]"
                     )
                     t_text = text  # Fallback to original text
                 else:
-                    time.sleep(1)  # Wait before retry
+                    time.sleep(min(60, 10 * attempt_count) if is_rate_limit else 1)
 
         end_time = time.time()
         print(f"[dim]Translation time: {end_time - start_time:.2f}s[/dim]")

--- a/tests/test_pdf_layout.py
+++ b/tests/test_pdf_layout.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from book_maker.loader.pdf_loader import create_bilingual_pdf
+
+
+def _run_check(tmp_dir):
+    pairs = [
+        ("Hello world\nThis is the original.", "你好，世界\n这是译文。"),
+        ("A longer English line that should wrap inside the PDF column.", "一行较长的中文译文，应当在 PDF 栏内自动换行。"),
+    ]
+    tmp_dir = Path(tmp_dir)
+    for layout in ("top-bottom", "side-by-side"):
+        out_path = tmp_dir / f"{layout}.pdf"
+        assert create_bilingual_pdf(pairs, out_path, "PDF layout test", layout)
+        assert out_path.exists()
+        assert out_path.stat().st_size > 0
+
+
+def test_pdf_layouts(tmp_path):
+    _run_check(tmp_path)
+
+
+if __name__ == "__main__":
+    with TemporaryDirectory() as tmp_dir:
+        _run_check(tmp_dir)

--- a/tests/test_pdf_layout.py
+++ b/tests/test_pdf_layout.py
@@ -7,7 +7,10 @@ from book_maker.loader.pdf_loader import create_bilingual_pdf
 def _run_check(tmp_dir):
     pairs = [
         ("Hello world\nThis is the original.", "你好，世界\n这是译文。"),
-        ("A longer English line that should wrap inside the PDF column.", "一行较长的中文译文，应当在 PDF 栏内自动换行。"),
+        (
+            "A longer English line that should wrap inside the PDF column.",
+            "一行较长的中文译文，应当在 PDF 栏内自动换行。",
+        ),
     ]
     tmp_dir = Path(tmp_dir)
     for layout in ("top-bottom", "side-by-side"):

--- a/tests/test_qwen_rate_limit.py
+++ b/tests/test_qwen_rate_limit.py
@@ -1,0 +1,11 @@
+from book_maker.translator.qwen_translator import QwenTranslator
+
+
+def test_qwen_rate_limit_detection():
+    assert QwenTranslator._is_rate_limit_error(Exception("Error code: 429"))
+    assert QwenTranslator._is_rate_limit_error(Exception("limit_requests"))
+    assert not QwenTranslator._is_rate_limit_error(Exception("network timeout"))
+
+
+if __name__ == "__main__":
+    test_qwen_rate_limit_detection()


### PR DESCRIPTION

## Summary
- Add bilingual PDF output for translated PDF books
- Add `--pdf_layout` with `top-bottom`, `side-by-side`, and `all`
- Add smoke tests for PDF generation
- Improve Qwen rate-limit handling to avoid silently falling back to original text

## Test
- `uv run --no-sync python -m py_compile book_maker/loader/pdf_loader.py book_maker/cli.py tests/test_pdf_layout.py tests/test_qwen_rate_limit.py`
- `uv run --no-sync python tests/test_pdf_layout.py`
- `uv run --no-sync python tests/test_qwen_rate_limit.py`
<img width="1066" height="835" alt="image" src="https://github.com/user-attachments/assets/870f92d7-f0ec-4261-a4a9-ac838b9808a6" />

