### PR TITLE
feat: add googlev3 model — official Cloud Translation v3 with glossar…

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -59,6 +59,44 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 make_book.py --book_name test_books/animal_farm.epub --model google
   ```
 
+* Google Cloud Translation v3（官方 API，支持术语表）
+
+  使用 `--model googlev3` 走官方 [Cloud Translation v3 API](https://cloud.google.com/translate/docs/advanced/translating-text-v3)，可通过 [glossary 术语表](https://cloud.google.com/translate/docs/advanced/glossary) 强制指定术语翻译。认证使用 ADC（Application Default Credentials），不需要 API key：
+
+  ```shell
+  # 二选一（注意：只跑 `gcloud auth login` 不够，ADC 是独立的一套凭证）：
+  gcloud auth application-default login                                # 个人账号
+  export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json  # 或服务账号（需 roles/cloudtranslate.user）
+
+  # 一次性项目配置
+  gcloud config set project my-proj
+  gcloud services enable translate.googleapis.com storage.googleapis.com
+  ```
+
+  先用 CSV 术语文件（每行 `源术语,目标术语`）一次性创建术语表（脚本会自动上传到 GCS 并注册 glossary，需要 `pip install google-cloud-storage`；服务账号还需 roles/cloudtranslate.editor 和 roles/storage.objectAdmin）：
+
+  ```shell
+  # bucket 必须已存在且位于 us-central1
+  gcloud storage buckets create gs://my-bucket --location=us-central1
+
+  python3 scripts/create_glossary.py \
+    --project_id my-proj --glossary_id my-terms \
+    --source_lang en --target_lang zh-CN \
+    --csv ./terms.csv --gcs_bucket my-bucket
+  ```
+
+  然后翻译时引用（使用术语表时必须显式指定 `--source_lang`；不传 `--google_glossary_id` 则为普通官方翻译）：
+
+  ```shell
+  python3 make_book.py --book_name test_books/animal_farm.epub --model googlev3 \
+    --google_project_id my-proj --google_glossary_id my-terms \
+    --source_lang en --language zh-hans
+  ```
+
+  `--google_project_id` 缺省时取 ADC 默认项目；`--google_location` 默认 `us-central1`（glossary 仅该区域支持）。环境变量兜底：`BBM_GOOGLE_PROJECT_ID`、`BBM_GOOGLE_GLOSSARY_ID`、`BBM_GOOGLE_LOCATION`。
+
+  代理环境：请求默认走 REST（gRPC 不识别代理，会报 `503 UNAVAILABLE`）；SOCKS 代理下还需 `pip install "requests[socks]"`。完整配置指南见 [docs/env_settings.md](docs/env_settings.md)。
+
 * 彩云小译
 
   ```shell
@@ -189,6 +227,7 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   | `qwen-mt-turbo` | `--qwen_key` / `BBM_QWEN_API_KEY` | 通义千问快速翻译模型 |
   | `qwen-mt-plus` | `--qwen_key` / `BBM_QWEN_API_KEY` | 通义千问高质量翻译模型 |
   | `google` | 无需 key | 免费谷歌翻译 |
+  | `googlev3` | ADC（`GOOGLE_APPLICATION_CREDENTIALS`） | 官方 Cloud Translation v3，支持 `--google_glossary_id` 术语表 |
   | `caiyun` | `--caiyun_key` / `BBM_CAIYUN_API_KEY` | 彩云小译 |
   | `deepl` | `--deepl_key` / `BBM_DEEPL_API_KEY` | DeepL（付费） |
   | `deeplfree` | 无需 key | DeepL 免费版 |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,44 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 make_book.py --book_name test_books/animal_farm.epub --model google
   ```
 
+* Google Cloud Translation v3 (official API, with glossary support)
+
+  Use `--model googlev3` for the official [Cloud Translation v3 API](https://cloud.google.com/translate/docs/advanced/translating-text-v3), which supports enforcing your own terminology via a [glossary](https://cloud.google.com/translate/docs/advanced/glossary). Authentication uses Application Default Credentials (ADC) instead of an API key:
+
+  ```shell
+  # one of the following (note: `gcloud auth login` alone is NOT enough for ADC):
+  gcloud auth application-default login                                # personal account
+  export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json  # or service account (roles/cloudtranslate.user)
+
+  # one-time project setup
+  gcloud config set project my-proj
+  gcloud services enable translate.googleapis.com storage.googleapis.com
+  ```
+
+  Create a glossary once from a CSV term file (`source term,target term` per line; the script uploads it to GCS and registers the glossary — this needs `pip install google-cloud-storage` and, for service accounts, roles/cloudtranslate.editor + roles/storage.objectAdmin):
+
+  ```shell
+  # the bucket must exist and be in us-central1
+  gcloud storage buckets create gs://my-bucket --location=us-central1
+
+  python3 scripts/create_glossary.py \
+    --project_id my-proj --glossary_id my-terms \
+    --source_lang en --target_lang zh-CN \
+    --csv ./terms.csv --gcs_bucket my-bucket
+  ```
+
+  Then translate with it (a glossary requires an explicit `--source_lang`; omit `--google_glossary_id` for plain official translation):
+
+  ```shell
+  python3 make_book.py --book_name test_books/animal_farm.epub --model googlev3 \
+    --google_project_id my-proj --google_glossary_id my-terms \
+    --source_lang en --language zh-hans
+  ```
+
+  `--google_project_id` defaults to the ADC project; `--google_location` defaults to `us-central1` (the only region supporting glossaries). Env fallbacks: `BBM_GOOGLE_PROJECT_ID`, `BBM_GOOGLE_GLOSSARY_ID`, `BBM_GOOGLE_LOCATION`.
+
+  Behind a proxy: requests go over REST by default (gRPC ignores proxies and fails with `503 UNAVAILABLE`); with a SOCKS proxy also run `pip install "requests[socks]"`. See [docs/env_settings.md](docs/env_settings.md) for the full setup guide.
+
 * Caiyun Translate
 
   ```shell
@@ -203,6 +241,7 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   | `qwen-mt-turbo` | `--qwen_key` / `BBM_QWEN_API_KEY` | Qwen fast translation model |
   | `qwen-mt-plus` | `--qwen_key` / `BBM_QWEN_API_KEY` | Qwen high-quality translation model |
   | `google` | N/A | Free. No API key needed |
+  | `googlev3` | ADC (`GOOGLE_APPLICATION_CREDENTIALS`) | Official Cloud Translation v3, supports `--google_glossary_id` |
   | `caiyun` | `--caiyun_key` / `BBM_CAIYUN_API_KEY` | Caiyun |
   | `deepl` | `--deepl_key` / `BBM_DEEPL_API_KEY` | DeepL (paid) |
   | `deeplfree` | N/A | DeepL Free |

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -200,6 +200,26 @@ def main():
         help="You can get Qwen Key from  https://bailian.console.aliyun.com/?tab=model#/api-key",
     )
 
+    # for Google Cloud Translation v3 (official API, auth via ADC)
+    parser.add_argument(
+        "--google_project_id",
+        dest="google_project_id",
+        type=str,
+        help="Google Cloud project id for googlev3 model, defaults to the ADC project (or set BBM_GOOGLE_PROJECT_ID)",
+    )
+    parser.add_argument(
+        "--google_glossary_id",
+        dest="google_glossary_id",
+        type=str,
+        help="Glossary id for googlev3 terminology translation, create one with scripts/create_glossary.py (or set BBM_GOOGLE_GLOSSARY_ID)",
+    )
+    parser.add_argument(
+        "--google_location",
+        dest="google_location",
+        type=str,
+        help="Google Cloud location for googlev3 model, default us-central1 (glossaries are only supported there)",
+    )
+
     parser.add_argument(
         "--test",
         dest="test",
@@ -527,6 +547,9 @@ So you are close to reaching the limit. You have to choose your own value, there
         API_KEY = options.xai_key or env.get("BBM_XAI_API_KEY")
     elif options.model and options.model.startswith("qwen-"):
         API_KEY = options.qwen_key or env.get("BBM_QWEN_API_KEY")
+    elif options.model == "googlev3":
+        # auth via Application Default Credentials, no API key needed
+        API_KEY = ""
     elif options.provider:
         env_key_name = provider_cfg.get("env_key", "") if provider_cfg else ""
         API_KEY = options.api_key or (env.get(env_key_name) if env_key_name else "")
@@ -679,6 +702,15 @@ So you are close to reaching the limit. You have to choose your own value, there
         e.translate_model.set_claude_model(options.model)
     if options.model and options.model.startswith("qwen-"):
         e.translate_model.set_qwen_model(options.model)
+    if options.model == "googlev3":
+        e.translate_model.set_config(
+            project_id=options.google_project_id or env.get("BBM_GOOGLE_PROJECT_ID"),
+            location=options.google_location
+            or env.get("BBM_GOOGLE_LOCATION")
+            or "us-central1",
+            glossary_id=options.google_glossary_id
+            or env.get("BBM_GOOGLE_GLOSSARY_ID"),
+        )
     if options.block_size > 0:
         e.block_size = options.block_size
     if options.batch_flag:

--- a/book_maker/translator/__init__.py
+++ b/book_maker/translator/__init__.py
@@ -3,6 +3,7 @@ from book_maker.translator.chatgptapi_translator import ChatGPTAPI
 from book_maker.translator.deepl_translator import DeepL
 from book_maker.translator.deepl_free_translator import DeepLFree
 from book_maker.translator.google_translator import Google
+from book_maker.translator.google_v3_translator import GoogleV3
 from book_maker.translator.claude_translator import Claude
 from book_maker.translator.gemini_translator import Gemini
 from book_maker.translator.groq_translator import GroqClient
@@ -23,6 +24,7 @@ MODEL_DICT = {
     "o1mini": ChatGPTAPI,
     "o3mini": ChatGPTAPI,
     "google": Google,
+    "googlev3": GoogleV3,
     "caiyun": Caiyun,
     "deepl": DeepL,
     "deeplfree": DeepLFree,

--- a/book_maker/translator/google_v3_translator.py
+++ b/book_maker/translator/google_v3_translator.py
@@ -1,0 +1,133 @@
+import os
+import time
+
+from book_maker.utils import TO_LANGUAGE_CODE
+from .base_translator import Base
+
+# Cloud Translation v3 expects BCP-47 codes and rejects some of the
+# internal codes used by this repo's language table.
+V3_LANGUAGE_CODE_FIX = {
+    "zh-hans": "zh-CN",
+    "zh": "zh-CN",
+    "zh-hant": "zh-TW",
+    "zh-yue": "yue",
+}
+
+ADC_HELP = """Google Cloud Application Default Credentials (ADC) not found.
+Set up one of the following, then retry:
+  1. Service account (recommended):
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+     The account needs the role `roles/cloudtranslate.user`.
+  2. Personal account (quick start):
+       gcloud auth application-default login
+       gcloud config set project <your-project-id>
+Also make sure the Cloud Translation API is enabled for your project:
+  https://console.cloud.google.com/apis/library/translate.googleapis.com"""
+
+PROJECT_HELP = (
+    "Google Cloud project id not found. Provide it via --google_project_id, "
+    "the BBM_GOOGLE_PROJECT_ID environment variable, "
+    "or `gcloud config set project <your-project-id>`."
+)
+
+
+class GoogleV3(Base):
+    """
+    Official Google Cloud Translation API v3, with optional glossary
+    (terminology) support. Authenticates via Application Default Credentials.
+    """
+
+    def __init__(self, key, language, source_lang="auto", **kwargs) -> None:
+        super().__init__(key or "adc", language)
+        code = TO_LANGUAGE_CODE.get(language.lower(), language)
+        self.target_lang = V3_LANGUAGE_CODE_FIX.get(code.lower(), code)
+        source_lang = source_lang or "auto"
+        self.source_lang = V3_LANGUAGE_CODE_FIX.get(
+            source_lang.lower(), source_lang
+        )
+        self.project_id = None
+        self.location = "us-central1"
+        self.glossary_id = None
+        self.client = None
+        self.parent = None
+        self.glossary_config = None
+
+    def rotate_key(self):
+        pass
+
+    def set_config(self, project_id=None, location=None, glossary_id=None):
+        self.project_id = project_id
+        if location:
+            self.location = location
+        self.glossary_id = glossary_id
+        if glossary_id and self.source_lang == "auto":
+            raise Exception(
+                "Glossary translation requires an explicit source language, "
+                "e.g. --source_lang en"
+            )
+
+    def _ensure_client(self):
+        if self.client is not None:
+            return
+        try:
+            from google.cloud import translate_v3
+        except ImportError as e:
+            raise Exception(
+                "google-cloud-translate is required for `--model googlev3`. "
+                "Install it with: pip install google-cloud-translate"
+            ) from e
+        import google.auth
+        from google.auth.exceptions import DefaultCredentialsError
+
+        try:
+            credentials, adc_project = google.auth.default()
+        except DefaultCredentialsError as e:
+            raise Exception(ADC_HELP) from e
+        if not self.project_id:
+            self.project_id = adc_project
+        if not self.project_id:
+            raise Exception(PROJECT_HELP)
+        # REST by default: gRPC bypasses SOCKS/HTTP proxies and often
+        # fails behind them, while REST honors standard proxy env vars.
+        transport = os.environ.get("BBM_GOOGLE_TRANSPORT", "rest")
+        self.client = translate_v3.TranslationServiceClient(
+            credentials=credentials, transport=transport
+        )
+        self.parent = f"projects/{self.project_id}/locations/{self.location}"
+        if self.glossary_id:
+            glossary_path = self.client.glossary_path(
+                self.project_id, self.location, self.glossary_id
+            )
+            self.glossary_config = translate_v3.TranslateTextGlossaryConfig(
+                glossary=glossary_path
+            )
+
+    def translate(self, text):
+        self._ensure_client()
+        request = {
+            "parent": self.parent,
+            "contents": [text],
+            "mime_type": "text/plain",
+            "target_language_code": self.target_lang,
+        }
+        if self.source_lang != "auto":
+            request["source_language_code"] = self.source_lang
+        if self.glossary_config is not None:
+            request["glossary_config"] = self.glossary_config
+
+        last_error = None
+        for attempt in range(3):
+            try:
+                response = self.client.translate_text(request=request)
+                if (
+                    self.glossary_config is not None
+                    and response.glossary_translations
+                ):
+                    return response.glossary_translations[0].translated_text
+                return response.translations[0].translated_text
+            except Exception as e:
+                last_error = e
+                time.sleep(2**attempt)
+        raise Exception(
+            f"Google Cloud Translation failed after retries: {last_error}"
+        ) from last_error

--- a/docs/env_settings.md
+++ b/docs/env_settings.md
@@ -9,3 +9,55 @@ export BBM_OPENAI_API_KEY=${your_api_key}
 # Set env BBM_CAIYUN_API_KEY to ignore option --caiyun_key
 export BBM_CAIYUN_API_KEY=${your_api_key}
 ```
+
+## Google Cloud Translation v3 (`--model googlev3`)
+
+No API key. Auth uses Application Default Credentials (ADC).
+
+### One-time setup
+
+```sh
+# 1. Install gcloud CLI (macOS)
+brew install --cask google-cloud-sdk
+
+# 2. Log in for ADC — this is what the code uses.
+#    Note: `gcloud auth login` alone is NOT enough; ADC is a separate credential.
+gcloud auth application-default login
+gcloud config set project ${your_project_id}
+
+# 3. Enable the APIs (Storage is only needed for glossary creation)
+gcloud services enable translate.googleapis.com storage.googleapis.com
+
+# 4. (glossary only) Create a bucket for term CSVs.
+#    Must be us-central1 — the only region that supports glossaries.
+gcloud storage buckets create gs://${your_bucket} --location=us-central1
+```
+
+Alternatively use a service account instead of step 2:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+Verify: `python3 -c "import google.auth; print(google.auth.default())"`
+
+### Env vars
+
+```sh
+# Ignore options --google_project_id / --google_glossary_id / --google_location
+export BBM_GOOGLE_PROJECT_ID=${your_project_id}   # defaults to the ADC project
+export BBM_GOOGLE_GLOSSARY_ID=${your_glossary_id}
+export BBM_GOOGLE_LOCATION=us-central1            # default; keep it for glossaries
+
+# Transport defaults to REST; set to grpc only if you don't need a proxy
+export BBM_GOOGLE_TRANSPORT=rest
+```
+
+### Behind a proxy
+
+- Transport defaults to REST because gRPC ignores SOCKS/HTTP proxies and fails
+  with `503 UNAVAILABLE: failed to connect to all addresses`. Keep the REST
+  default if you are behind a proxy.
+- With a SOCKS proxy (`all_proxy=socks5://...`) you also need:
+  `pip install "requests[socks]"`, otherwise requests raises
+  `Missing dependencies for SOCKS support`.

--- a/docs/model_lang.md
+++ b/docs/model_lang.md
@@ -2,7 +2,7 @@
 ## Models
 `-m, --model <Model>` <br>
 
-Currently `bbook_maker` supports these models: `chatgptapi` , `gpt3` , `google` , `caiyun` , `deepl` , `deeplfree` , `gpt4` , `gpt4omini` , `gpt5mini` , `o1-preview` , `o1` , `o1-mini` , `o3-mini` , `claude` , `customapi`.
+Currently `bbook_maker` supports these models: `chatgptapi` , `gpt3` , `google` , `googlev3` , `caiyun` , `deepl` , `deeplfree` , `gpt4` , `gpt4omini` , `gpt5mini` , `o1-preview` , `o1` , `o1-mini` , `o3-mini` , `claude` , `customapi`.
 Default model is `chatgptapi` . 
 
 ### OPENAI models
@@ -110,6 +110,21 @@ Support CustomAPI model. Use `--model customapi --custom_api ${custom_api}` .
 ### Google
 
 Support google model. Use `--model google`
+
+### Google Cloud Translation v3 (official, glossary support)
+
+Use `--model googlev3` for the official Cloud Translation v3 API with optional glossary (terminology) support. Authentication uses Application Default Credentials (`GOOGLE_APPLICATION_CREDENTIALS` or `gcloud auth application-default login`).
+
+    # create a glossary once from a CSV term file (uploads to GCS automatically)
+    python3 scripts/create_glossary.py --project_id my-proj --glossary_id my-terms \
+        --source_lang en --target_lang zh-CN --csv ./terms.csv --gcs_bucket my-bucket
+
+    # translate with the glossary (requires explicit --source_lang)
+    bbook_maker --book_name test_books/animal_farm.epub --model googlev3 \
+        --google_project_id my-proj --google_glossary_id my-terms \
+        --source_lang en --language zh-hans
+
+Omit `--google_glossary_id` for plain official translation. `--google_location` defaults to `us-central1` (the only region supporting glossaries). Env fallbacks: `BBM_GOOGLE_PROJECT_ID`, `BBM_GOOGLE_GLOSSARY_ID`, `BBM_GOOGLE_LOCATION`.
 
 ## Languages
 `--language <LANGUAGE>` <br>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "backoff",
     "bs4",
     "ebooklib",
+    "google-cloud-translate>=3.15.0",
     "google-genai",
     "litellm",
     "openai>=1.1.1",

--- a/scripts/create_glossary.py
+++ b/scripts/create_glossary.py
@@ -1,0 +1,169 @@
+"""Create (or recreate) a Google Cloud Translation v3 glossary from a CSV term file.
+
+The CSV is an unidirectional glossary: two columns per line, source term
+then target term, no header. Example (en -> zh-CN):
+
+    account,账户
+    Neural Machine Translation,神经机器翻译
+
+Usage:
+
+    # from a local CSV (uploaded to GCS automatically)
+    python scripts/create_glossary.py \
+        --project_id my-proj --glossary_id my-terms \
+        --source_lang en --target_lang zh-CN \
+        --csv ./terms.csv --gcs_bucket my-bucket
+
+    # from a CSV already in GCS
+    python scripts/create_glossary.py \
+        --project_id my-proj --glossary_id my-terms \
+        --source_lang en --target_lang zh-CN \
+        --csv gs://my-bucket/glossaries/my-terms.csv
+
+Authentication uses Application Default Credentials:
+    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+or
+    gcloud auth application-default login
+
+The account needs roles/cloudtranslate.editor, plus
+roles/storage.objectAdmin when uploading a local CSV.
+"""
+
+import argparse
+import sys
+
+ADC_HELP = """Google Cloud Application Default Credentials (ADC) not found.
+Set up one of the following, then retry:
+  1. export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+  2. gcloud auth application-default login"""
+
+
+def upload_csv_to_gcs(bucket_name, glossary_id, csv_path):
+    try:
+        from google.cloud import storage
+    except ImportError:
+        sys.exit(
+            "google-cloud-storage is required to upload a local CSV.\n"
+            "Install it with: pip install google-cloud-storage\n"
+            "(or upload the CSV yourself and pass a gs:// URI to --csv)"
+        )
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    if not bucket.exists():
+        sys.exit(
+            f"GCS bucket '{bucket_name}' not found. Create it first, e.g.:\n"
+            f"  gcloud storage buckets create gs://{bucket_name} --location=us-central1"
+        )
+    blob_name = f"glossaries/{glossary_id}.csv"
+    bucket.blob(blob_name).upload_from_filename(csv_path)
+    uri = f"gs://{bucket_name}/{blob_name}"
+    print(f"Uploaded {csv_path} -> {uri}")
+    return uri
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--project_id", required=True)
+    parser.add_argument("--glossary_id", required=True)
+    parser.add_argument(
+        "--source_lang", required=True, help="BCP-47 code, e.g. en"
+    )
+    parser.add_argument(
+        "--target_lang", required=True, help="BCP-47 code, e.g. zh-CN"
+    )
+    parser.add_argument(
+        "--csv",
+        required=True,
+        help="local CSV path (needs --gcs_bucket) or a gs:// URI",
+    )
+    parser.add_argument(
+        "--gcs_bucket", help="GCS bucket to upload a local CSV into"
+    )
+    parser.add_argument(
+        "--location",
+        default="us-central1",
+        help="glossaries are only supported in us-central1",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="delete and recreate the glossary if it already exists",
+    )
+    args = parser.parse_args()
+
+    try:
+        from google.cloud import translate_v3
+    except ImportError:
+        sys.exit(
+            "google-cloud-translate is required.\n"
+            "Install it with: pip install google-cloud-translate"
+        )
+    from google.api_core.exceptions import AlreadyExists, NotFound
+    from google.auth.exceptions import DefaultCredentialsError
+
+    if args.csv.startswith("gs://"):
+        input_uri = args.csv
+    else:
+        if not args.gcs_bucket:
+            sys.exit("--gcs_bucket is required when --csv is a local file")
+        input_uri = upload_csv_to_gcs(
+            args.gcs_bucket, args.glossary_id, args.csv
+        )
+
+    import os
+
+    try:
+        # REST by default: gRPC bypasses SOCKS/HTTP proxies and often
+        # fails behind them, while REST honors standard proxy env vars.
+        transport = os.environ.get("BBM_GOOGLE_TRANSPORT", "rest")
+        client = translate_v3.TranslationServiceClient(transport=transport)
+    except DefaultCredentialsError:
+        sys.exit(ADC_HELP)
+
+    parent = f"projects/{args.project_id}/locations/{args.location}"
+    glossary_name = client.glossary_path(
+        args.project_id, args.location, args.glossary_id
+    )
+    glossary = translate_v3.Glossary(
+        name=glossary_name,
+        language_pair=translate_v3.Glossary.LanguageCodePair(
+            source_language_code=args.source_lang,
+            target_language_code=args.target_lang,
+        ),
+        input_config=translate_v3.GlossaryInputConfig(
+            gcs_source=translate_v3.GcsSource(input_uri=input_uri)
+        ),
+    )
+
+    if args.force:
+        try:
+            print(f"Deleting existing glossary {glossary_name} ...")
+            client.delete_glossary(name=glossary_name).result(timeout=300)
+        except NotFound:
+            pass
+
+    try:
+        operation = client.create_glossary(parent=parent, glossary=glossary)
+        result = operation.result(timeout=300)
+    except AlreadyExists:
+        sys.exit(
+            f"Glossary '{args.glossary_id}' already exists. "
+            "Rerun with --force to delete and recreate it "
+            "(v3 glossaries cannot be updated in place)."
+        )
+    except DefaultCredentialsError:
+        sys.exit(ADC_HELP)
+
+    print(f"Created glossary: {result.name}")
+    print(f"Entries: {result.entry_count}")
+    print(
+        "Use it with:\n"
+        f"  bbook_maker --model googlev3 --google_project_id {args.project_id} "
+        f"--google_glossary_id {args.glossary_id} "
+        f"--source_lang {args.source_lang} --language <target> "
+        "--book_name <book>"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_google_v3.py
+++ b/tests/test_google_v3.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from book_maker.translator import MODEL_DICT
+from book_maker.translator.google_v3_translator import GoogleV3
+
+
+def make_translator(language="simplified chinese", source_lang="en"):
+    return GoogleV3("", language, source_lang=source_lang)
+
+
+def test_googlev3_registered_in_model_dict():
+    assert MODEL_DICT["googlev3"] is GoogleV3
+
+
+def test_language_codes_normalized_for_v3():
+    t = make_translator(language="simplified chinese")
+    assert t.target_lang == "zh-CN"
+    t = make_translator(language="traditional chinese")
+    assert t.target_lang == "zh-TW"
+    t = make_translator(language="ja")
+    assert t.target_lang == "ja"
+
+
+def test_glossary_requires_explicit_source_lang():
+    t = make_translator(source_lang="auto")
+    with pytest.raises(Exception, match="source language"):
+        t.set_config(project_id="p", glossary_id="g")
+
+
+def test_set_config_defaults_location():
+    t = make_translator()
+    t.set_config(project_id="p", location=None, glossary_id="g")
+    assert t.location == "us-central1"
+    assert t.glossary_id == "g"
+
+
+def make_mocked_client(t, glossary=False):
+    t.client = MagicMock()
+    t.parent = "projects/p/locations/us-central1"
+    if glossary:
+        t.glossary_config = MagicMock()
+    response = MagicMock()
+    response.translations = [MagicMock(translated_text="plain")]
+    response.glossary_translations = [MagicMock(translated_text="glossary")]
+    t.client.translate_text.return_value = response
+    return t.client
+
+
+def test_translate_uses_glossary_translation():
+    t = make_translator()
+    client = make_mocked_client(t, glossary=True)
+    assert t.translate("hello") == "glossary"
+    request = client.translate_text.call_args.kwargs["request"]
+    assert request["glossary_config"] is t.glossary_config
+    assert request["source_language_code"] == "en"
+    assert request["target_language_code"] == "zh-CN"
+    assert request["contents"] == ["hello"]
+
+
+def test_translate_without_glossary():
+    t = make_translator()
+    client = make_mocked_client(t, glossary=False)
+    assert t.translate("hello") == "plain"
+    request = client.translate_text.call_args.kwargs["request"]
+    assert "glossary_config" not in request
+
+
+def test_translate_omits_source_lang_when_auto():
+    t = make_translator(source_lang="auto")
+    client = make_mocked_client(t)
+    t.translate("hello")
+    request = client.translate_text.call_args.kwargs["request"]
+    assert "source_language_code" not in request


### PR DESCRIPTION
…y support

- New GoogleV3 translator using the official google-cloud-translate v3 client with optional glossaryConfig for terminology enforcement. Auth via Application Default Credentials (no API key); REST transport by default (gRPC bypasses SOCKS/HTTP proxies), override with BBM_GOOGLE_TRANSPORT=grpc.
- CLI: --google_project_id / --google_glossary_id / --google_location (env fallbacks BBM_GOOGLE_*); project id defaults to the ADC project; glossary mode requires an explicit --source_lang.
- scripts/create_glossary.py: one-shot local CSV -> GCS upload ->
  glossary creation (--force to recreate; v3 glossaries are immutable).
- Docs: setup guide (ADC, API enablement, us-central1 bucket, proxy pitfalls) in README, README-CN, docs/model_lang.md, docs/env_settings.md.
- Tests: unit tests with mocked client (8 passing); verified end-to-end against a real GCP project incl. glossary-enforced EPUB translation.