### PR TITLE
fix(epub): avoid leaking raw HTML tags into translated text

### DIFF
--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -532,7 +532,9 @@ class EPUBBookLoader(BaseBookLoader):
         if not wait_p_list:
             return
 
-        result_txt_list = self.translate_model.translate_list(wait_p_list)
+        result_txt_list = self.translate_model.translate_list(
+            [p.text for p in wait_p_list]
+        )
 
         for i in range(len(wait_p_list)):
             if i < len(result_txt_list):
@@ -1042,7 +1044,9 @@ class EPUBBookLoader(BaseBookLoader):
                     )
 
                     # Call translate_list for consistent batch translation logic
-                    result_txt_list = self.translator.translate_list(wait_p_list)
+                    result_txt_list = self.translator.translate_list(
+                        [p.text for p in wait_p_list]
+                    )
 
                     # Update chapter context from translator
                     self.context_list[:] = self.translator.context_list

--- a/book_maker/loader/helper.py
+++ b/book_maker/loader/helper.py
@@ -55,7 +55,9 @@ class EPUBBookLoaderHelper:
         if not wait_p_list:
             return
 
-        result_txt_list = self.translate_model.translate_list(wait_p_list)
+        result_txt_list = self.translate_model.translate_list(
+            [p.text for p in wait_p_list]
+        )
 
         for i in range(len(wait_p_list)):
             if i < len(result_txt_list):

--- a/tests/test_epub_loader_batch_translate.py
+++ b/tests/test_epub_loader_batch_translate.py
@@ -1,0 +1,47 @@
+from bs4 import BeautifulSoup as bs
+
+from book_maker.loader.epub_loader import EPUBBookLoader
+from book_maker.loader.helper import EPUBBookLoaderHelper
+
+
+class FakeTranslateModel:
+    TRANSLATION_ERROR_MARKER = "[Translation failed for this paragraph]"
+
+    def __init__(self):
+        self.received = None
+
+    def translate_list(self, text_list):
+        self.received = list(text_list)
+        return [f"translated:{t}" for t in text_list]
+
+
+def _make_loader(translate_model):
+    loader = EPUBBookLoader.__new__(EPUBBookLoader)
+    loader.translate_model = translate_model
+    loader.exclude_translate_tags = "sup,code"
+    loader.translation_style = ""
+    loader.helper = EPUBBookLoaderHelper(translate_model, 1, "", False)
+    return loader
+
+
+def test_deal_old_acc_sends_plain_text_not_html_tags():
+    # Regression test: a nav/TOC-style paragraph with class/id attributes
+    # used to be stringified (tags and all) before being sent to the
+    # translation model, leaking raw HTML into the translated output.
+    soup = bs(
+        '<p class="toccn" id="chapter_2">Chapter 2: SWITZERLAND: Happiness Is Boredom</p>',
+        "html.parser",
+    )
+    p = soup.find("p")
+    translate_model = FakeTranslateModel()
+    loader = _make_loader(translate_model)
+
+    loader._deal_old_acc([p], False)
+
+    assert translate_model.received == ["Chapter 2: SWITZERLAND: Happiness Is Boredom"]
+
+    inserted = soup.find_all("p")[-1]
+    assert "<" not in inserted.get_text()
+    assert inserted.get_text() == (
+        "translated:Chapter 2: SWITZERLAND: Happiness Is Boredom"
+    )


### PR DESCRIPTION
## Summary
- Fix a bug where BeautifulSoup `Tag` objects were passed directly to `translate_model.translate_list()` in three duplicated call sites, causing raw HTML tag syntax (e.g. `<p class="toccn" id="chapter_2">`) to leak into the translated output.
- Extract plain text via `[p.text for p in wait_p_list]` before calling `translate_list()`, matching the already-correct pattern already used in `_process_combined_paragraph`.
- Add a regression test covering the leak.

## Reproduction
1. Run with `--accumulated_num` (or `--parallel-workers`) on an EPUB that has a short, single-paragraph chapter (typical for a table of contents entry or dedication page).
2. The resulting bilingual EPUB shows the literal tag string (e.g. `<p class="toccn" id="chapter_2">...`) instead of clean translated text on that page.

## Root cause
`wait_p_list` holds BeautifulSoup `Tag` objects (kept around so theoriginal tag/attributes can be copied back in when the translation isre-inserted). Three near-identical implementations(`EPUBBookLoader._deal_old_acc`, the nested `ChapterHelper.deal_old`used by `--parallel-workers`, and the unused`EPUBBookLoaderHelper.deal_old`) passed `wait_p_list` straight into`translate_model.translate_list()`. The batch translation paths call`str(t)` on each item, which stringifies the whole tag(`<p ...>...</p>`) instead of just its text, so the model caninterpret the markup as part of "the text to translate" and echo itback. This is not book- or model-specific: any backend using `--accumulated_num` or `--parallel-workers` hits the same code path.

## Fix
Extract `p.text` before calling `translate_list()` in all three call sites, mirroring the correct pattern already used in `_process_combined_paragraph` (`raw = p.text.rstrip()`). The tag-preserving re-insertion logic (`_insert_trans_preserving_tags` / `insert_trans`, which `copy()`s the original tag and only replaces its inner string) is untouched, so this does not affect layout/formatting.

## Test plan
- [x] Added `tests/test_epub_loader_batch_translate.py`, which builds a `<p class="toccn" id="chapter_2">...</p>` tag, calls `_deal_old_acc([p], False)`, and asserts the translator receives plain text (no `<`) rather than the tag object.
- [x] `pytest tests/`
`pytest tests/` — 54 passed, 7 skipped, 1 failed. The failure (`test_deepl_free_translate_epub`) is pre-existing and unrelated: it fails the same way on clean `upstream/main` (a live DeepL/PyDeepLX network call), on a different code path.
- [x] `black --check` on changed files
