### PR TITLE
fix(gemini): skip empty paragraphs in batch translation

### DIFF
--- a/book_maker/translator/gemini_translator.py
+++ b/book_maker/translator/gemini_translator.py
@@ -395,14 +395,13 @@ class Gemini(Base):
 
         stripped_texts = [str(t).strip() for t in text_list]
 
-        # Empty/whitespace paragraphs are dropped by the model, producing a
-        # spurious "expected N, got N-1" count mismatch. Send only the non-empty
-        # paragraphs and re-insert the empties (unchanged) afterwards so the
-        # count check stays strict for genuine omissions.
+        # The model silently drops empty/whitespace paragraphs, causing a bogus
+        # "expected N, got N-1" mismatch. Send only the non-empty ones.
         non_empty_indices = [i for i, s in enumerate(stripped_texts) if s]
         non_empty_texts = [stripped_texts[i] for i in non_empty_indices]
 
         if not non_empty_texts:
+            # Nothing to translate — return the originals unchanged.
             return list(text_list)
 
         expected_count = len(non_empty_texts)
@@ -423,8 +422,7 @@ class Gemini(Base):
             return [self.TRANSLATION_ERROR_MARKER] * batch_size
 
         if result:
-            # Re-insert translations at their original positions; empty paragraphs
-            # keep their original (untranslated) content.
+            # Put each translation back at its original index; empty paragraphs stay as-is.
             merged = list(text_list)
             for idx, value in zip(non_empty_indices, result):
                 merged[idx] = value

--- a/book_maker/translator/gemini_translator.py
+++ b/book_maker/translator/gemini_translator.py
@@ -394,16 +394,28 @@ class Gemini(Base):
             return [self.TRANSLATION_ERROR_MARKER] * batch_size
 
         stripped_texts = [str(t).strip() for t in text_list]
-        batch_text = "\n\n".join(stripped_texts)
+
+        # Empty/whitespace paragraphs are dropped by the model, producing a
+        # spurious "expected N, got N-1" count mismatch. Send only the non-empty
+        # paragraphs and re-insert the empties (unchanged) afterwards so the
+        # count check stays strict for genuine omissions.
+        non_empty_indices = [i for i, s in enumerate(stripped_texts) if s]
+        non_empty_texts = [stripped_texts[i] for i in non_empty_indices]
+
+        if not non_empty_texts:
+            return list(text_list)
+
+        expected_count = len(non_empty_texts)
+        batch_text = "\n\n".join(non_empty_texts)
 
         prompt = self.prompt.format(text=batch_text, language=self.language)
         if "translated_paragraphs" not in prompt.lower():
             prompt += (
                 f"\n\nReturn the translations as a JSON object with a 'translated_paragraphs' "
-                f"field containing exactly {batch_size} translated texts in order."
+                f"field containing exactly {expected_count} translated texts in order."
             )
 
-        result = self._batch_translate_with_retry(prompt, batch_size)
+        result = self._batch_translate_with_retry(prompt, expected_count)
 
         # Check again after retry attempt (error may have been detected during retries)
         if self._fatal_error_detected:
@@ -411,7 +423,12 @@ class Gemini(Base):
             return [self.TRANSLATION_ERROR_MARKER] * batch_size
 
         if result:
-            return result
+            # Re-insert translations at their original positions; empty paragraphs
+            # keep their original (untranslated) content.
+            merged = list(text_list)
+            for idx, value in zip(non_empty_indices, result):
+                merged[idx] = value
+            return merged
 
         # Fallback to one-by-one translation (only for non-fatal errors)
         print(

--- a/tests/test_gemini_batch_translate.py
+++ b/tests/test_gemini_batch_translate.py
@@ -1,0 +1,141 @@
+import json
+
+from book_maker.translator.gemini_translator import Gemini
+
+
+def _make_gemini():
+    """Build a Gemini instance without running __init__ (no API client / network)."""
+    g = Gemini.__new__(Gemini)
+    g.prompt = "Translate `{text}` to {language}"
+    g.language = "ja"
+    g._fatal_error_detected = False
+    return g
+
+
+def _stub_retry(g, captured):
+    """Replace the network call: record args, echo one translation per requested item."""
+
+    def fake(prompt, expected_count):
+        captured["prompt"] = prompt
+        captured["expected_count"] = expected_count
+        return [f"t{i}" for i in range(expected_count)]
+
+    g._batch_translate_with_retry = fake
+
+
+# 1. Regression: an empty paragraph is not sent and is preserved in place.
+def test_empty_paragraph_not_sent_and_preserved():
+    g = _make_gemini()
+    captured = {}
+    _stub_retry(g, captured)
+
+    result = g._batch_translate(["A", "", "B"], batch_size=3)
+
+    assert captured["expected_count"] == 2
+    assert "A" in captured["prompt"] and "B" in captured["prompt"]
+    assert result == ["t0", "", "t1"]
+
+
+# 2. All paragraphs empty: API is not called, originals returned unchanged.
+def test_all_empty_returns_originals_without_api_call():
+    g = _make_gemini()
+    called = {"n": 0}
+
+    def fake(prompt, expected_count):
+        called["n"] += 1
+        return []
+
+    g._batch_translate_with_retry = fake
+
+    original = ["", "  ", "\n"]
+    result = g._batch_translate(original, batch_size=3)
+
+    assert called["n"] == 0
+    assert result == original
+
+
+# 3. No empty paragraphs: all sent, order preserved (normal-path regression).
+def test_no_empty_translates_all_in_order():
+    g = _make_gemini()
+    captured = {}
+    _stub_retry(g, captured)
+
+    result = g._batch_translate(["A", "B", "C"], batch_size=3)
+
+    assert captured["expected_count"] == 3
+    assert result == ["t0", "t1", "t2"]
+
+
+# 4. Empties at edges / consecutive: translations land at correct indices.
+def test_empty_at_edges_and_consecutive_keep_positions():
+    g = _make_gemini()
+    captured = {}
+    _stub_retry(g, captured)
+
+    result = g._batch_translate(["", "A", "", "", "B"], batch_size=5)
+
+    assert captured["expected_count"] == 2
+    assert result == ["", "t0", "", "", "t1"]
+
+
+# 5. Whitespace-only variants count as empty.
+def test_whitespace_only_treated_as_empty():
+    g = _make_gemini()
+    captured = {}
+    _stub_retry(g, captured)
+
+    result = g._batch_translate([" ", "\t", "X", "\n"], batch_size=4)
+
+    assert captured["expected_count"] == 1
+    assert result == [" ", "\t", "t0", "\n"]
+
+
+# 6. Count check stays strict: a short response is rejected, an exact one accepted.
+def test_parse_rejects_short_response():
+    g = _make_gemini()
+    short = json.dumps({"translated_paragraphs": ["only-one"]})
+    assert g._parse_batch_response(short, expected_count=2) is None
+
+
+def test_parse_accepts_exact_response():
+    g = _make_gemini()
+    ok = json.dumps({"translated_paragraphs": ["a", "b"]})
+    assert g._parse_batch_response(ok, expected_count=2) == ["a", "b"]
+
+
+# 7. translate_list dispatch: 0 -> [], 1 -> translate(), many -> _batch_translate().
+def test_translate_list_empty_returns_empty():
+    g = _make_gemini()
+    assert g.translate_list([]) == []
+
+
+def test_translate_list_single_uses_translate():
+    g = _make_gemini()
+    g.translate = lambda text: f"single:{text}"
+    assert g.translate_list(["hello"]) == ["single:hello"]
+
+
+def test_translate_list_multiple_uses_batch():
+    g = _make_gemini()
+    seen = {}
+
+    def fake_batch(text_list, batch_size):
+        seen["batch_size"] = batch_size
+        return ["x"] * batch_size
+
+    g._batch_translate = fake_batch
+
+    result = g.translate_list(["a", "b"])
+
+    assert seen["batch_size"] == 2
+    assert result == ["x", "x"]
+
+
+# 8. Fatal error already detected: return error markers sized to batch_size.
+def test_fatal_error_returns_markers():
+    g = _make_gemini()
+    g._fatal_error_detected = True
+
+    result = g._batch_translate(["A", "B", "C"], batch_size=3)
+
+    assert result == [Gemini.TRANSLATION_ERROR_MARKER] * 3


### PR DESCRIPTION

## Summary

When translating an EPUB, any batch that contains an empty (whitespace-only) paragraph crashes the whole run:

```
Warning: Expected 21 translations, got 20. Retrying...
...
ValueError: Invalid batch translation response
```

The empty paragraph is sent in the batch, but the model drops it from the response. The batch is then permanently one translation short, so all 7 retries fail and translation aborts.

## Fix

In `_batch_translate`, send only the non-empty paragraphs, then put the translations back at their original positions and leave the empty paragraphs unchanged.

- Empty paragraphs can no longer cause a count mismatch.
- The count check still uses the number of paragraphs actually sent, so a genuinely missing translation is still caught and retried.
- Output keeps the same length and order as the input.
- A batch that is entirely empty returns without calling the API.

## Tests

New `tests/test_gemini_batch_translate.py` (11 cases, API stubbed so they run offline): skip-and-reinsert, empties at the start/end/middle, whitespace-only detection, the all-empty short-circuit, the strict count check, `translate_list` dispatch, and the fatal-error path.

## Note

This only fixes the empty-paragraph case. A different mismatch — the model returning more items than were sent (e.g. `expected 40, got 41`) — already exists on `main` and is unrelated.
