### PR TITLE
fix: verify JSON schema support in OpenAI probes instead of assuming it

### DIFF
--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -5,15 +5,27 @@ import shutil
 from os import environ
 from itertools import cycle
 import json
-from threading import Lock
+from threading import Lock, RLock
 
-from openai import AzureOpenAI, BadRequestError, NotFoundError, OpenAI, RateLimitError
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    AuthenticationError,
+    AzureOpenAI,
+    BadRequestError,
+    NotFoundError,
+    OpenAI,
+    PermissionDeniedError,
+    RateLimitError,
+)
+from pydantic import BaseModel, ConfigDict, ValidationError
 from rich import print
 from tenacity import (
     retry,
     stop_after_attempt,
     wait_exponential,
     retry_if_exception_type,
+    retry_if_not_exception_type,
 )
 
 from .base_translator import Base
@@ -26,19 +38,37 @@ PROMPT_ENV_MAP = {
     "system": "BBM_CHATGPTAPI_SYS_MSG",
 }
 
-# JSON Schema for structured batch translation output (OpenAI compatible)
-TRANSLATION_SCHEMA = {
-    "name": "translation_response",
-    "strict": True,
-    "schema": {
-        "type": "object",
-        "properties": {"paragraphs": {"type": "array", "items": {"type": "string"}}},
-        "required": ["paragraphs"],
-        "additionalProperties": False,
-    },
-}
 
-# Simpler schema for single translations
+class StructuredOutputUnsupported(Exception):
+    """The endpoint does not really apply the JSON Schema we sent.
+
+    Raised only for capability answers, never for model or transport errors, so
+    callers can demote to the delimiter method instead of retrying.
+    """
+
+
+class BatchTranslation(BaseModel):
+    """Structured batch translation output (OpenAI Structured Outputs)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    paragraphs: list[str]
+
+
+class SingleTranslation(BaseModel):
+    """Structured single translation output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    translated: str
+
+
+# Capability probe. The prompt asks for plain text and the schema pins a
+# single-value enum, so the only way `PROBE_EXPECTED` can come back is if the
+# server actually applied the schema to decoding. A proxy that accepts
+# `response_format` and quietly drops it answers with the prompted text instead.
+# Mirror of SingleTranslation for the Batch API, whose JSONL bodies are built by
+# hand and therefore cannot use the SDK's Pydantic support.
 SINGLE_TRANSLATION_SCHEMA = {
     "name": "single_translation",
     "strict": True,
@@ -49,6 +79,31 @@ SINGLE_TRANSLATION_SCHEMA = {
         "additionalProperties": False,
     },
 }
+
+PROBE_PROMPT = "Reply with the single word: ignored. Do not output JSON."
+PROBE_KEY = "probe"
+PROBE_EXPECTED = "schema_ok"
+STRUCTURED_PROBE_SCHEMA = {
+    "name": "structured_output_probe",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "properties": {PROBE_KEY: {"type": "string", "enum": [PROBE_EXPECTED]}},
+        "required": [PROBE_KEY],
+        "additionalProperties": False,
+    },
+}
+
+# Errors that say nothing about JSON Schema support. Swallowing these would pin
+# the whole run to the delimiter method because of a bad key or a flaky network.
+PROBE_FATAL_ERRORS = (
+    AuthenticationError,
+    PermissionDeniedError,
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    NotFoundError,
+)
 
 GPT35_MODEL_LIST = [
     "gpt-3.5-turbo",
@@ -101,6 +156,10 @@ O3MINI_MODEL_LIST = [
 class ChatGPTAPI(Base):
     DEFAULT_PROMPT = "Please help me to translate,`{text}` to {language}, please return only translated content not include the origin text"
 
+    # Subclasses that do not route through `self.openai_client` must opt out:
+    # probing them would send the capability request to the wrong endpoint.
+    SUPPORTS_STRUCTURED_OUTPUTS = True
+
     def __init__(
         self,
         key,
@@ -149,32 +208,120 @@ class ChatGPTAPI(Base):
         self.batch_info_cache = None
         self.result_content_cache = {}
         self._api_lock = Lock()
+        # Reentrant: the probe records its verdict while still holding the lock.
+        self._structured_lock = RLock()
         self.extra_body = extra_body or {}
 
-        # Structured outputs: auto-detected on first translate_list() call
-        # None means "not yet tested", will be set to True/False after test
-        self._use_structured_outputs = None
+        # Structured outputs: probed once per model on first use. Keyed by model
+        # because --model_list rotates across models of differing capability.
+        self._structured_support = {}
         self.model = (
             None  # Will be set by rotate_model() after model_list is initialized
         )
 
-    def _test_structured_outputs(self):
-        """Test if the server supports structured outputs (strict json schema)"""
+    def _ensure_structured_support(self, model=None):
+        """Resolve (once per model) whether structured outputs can be used.
+
+        The probe runs while holding the lock so that N parallel workers issue
+        one probe per model, not N.
+        """
+        model = model or self.model
+        with self._structured_lock:
+            if model not in self._structured_support:
+                if self.SUPPORTS_STRUCTURED_OUTPUTS:
+                    self._test_structured_outputs(model)
+                else:
+                    self._structured_support[model] = False
+            return self._structured_support.get(model, False)
+
+    def _structured_enabled(self):
+        return self._structured_support.get(self.model, False)
+
+    def _demote_structured_outputs(self, reason):
+        """Stop using structured outputs for this model after a real failure.
+
+        Without this, every later batch pays three tenacity attempts with
+        exponential backoff before falling back.
+        """
+        with self._structured_lock:
+            already_demoted = self._structured_support.get(self.model) is False
+            self._structured_support[self.model] = False
+        if not already_demoted:
+            print(
+                f"[yellow]ℹ '{self.model}' did not honor the JSON schema ({reason}); "
+                f"switching to the delimiter method[/yellow]"
+            )
+
+    def _test_structured_outputs(self, model=None):
+        """Probe whether the endpoint really applies a strict JSON Schema.
+
+        Grades the response body: accepting the request proves nothing, because
+        OpenAI-compatible proxies routinely accept `response_format` and drop it.
+        No temperature and no token cap — the probe must test exactly one
+        capability, and a cap would be rejected by o-series/gpt-5 models or eaten
+        by reasoning tokens, producing a false negative.
+        """
+        model = model or self.model
         try:
-            test_messages = [{"role": "user", "content": "Say 'test'"}]
-            self.openai_client.chat.completions.create(
-                model=self.model,
-                messages=test_messages,
+            completion = self.openai_client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": PROBE_PROMPT}],
                 response_format={
                     "type": "json_schema",
-                    "json_schema": SINGLE_TRANSLATION_SCHEMA,
+                    "json_schema": STRUCTURED_PROBE_SCHEMA,
                 },
             )
-            self._use_structured_outputs = True
-        except Exception:
-            self._use_structured_outputs = False
+        except PROBE_FATAL_ERRORS:
+            raise
+        except Exception as e:
+            # Ambiguous (400 for an unknown param, 500 from a local server, ...):
+            # not a usable endpoint for schemas either way, so degrade loudly.
+            self._record_probe_result(model, False, f"request rejected: {e}")
+            return
+
+        verdict = self._grade_probe_response(completion)
+        self._record_probe_result(model, verdict != "unsupported", verdict)
+
+    @staticmethod
+    def _grade_probe_response(completion):
+        """Return 'strict', 'shape' or 'unsupported' for a probe completion."""
+        choice = completion.choices[0]
+        if getattr(choice, "finish_reason", "stop") != "stop":
+            return "unsupported"
+
+        content = getattr(choice.message, "content", None)
+        if not content:
+            return "unsupported"
+
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            return "unsupported"
+
+        # Exact key set, so a json-mode-only server (right JSON, arbitrary keys)
+        # and a server ignoring additionalProperties both fail here.
+        if not isinstance(parsed, dict) or set(parsed) != {PROBE_KEY}:
+            return "unsupported"
+        if not isinstance(parsed[PROBE_KEY], str):
+            return "unsupported"
+
+        # Some backends honor the structure but ignore `enum`. Still usable: our
+        # real schemas constrain shape only, never values.
+        return "strict" if parsed[PROBE_KEY] == PROBE_EXPECTED else "shape"
+
+    def _record_probe_result(self, model, supported, verdict):
+        with self._structured_lock:
+            self._structured_support[model] = supported
+        if supported:
+            if verdict == "shape":
+                print(
+                    f"[yellow]ℹ '{model}' honors JSON schema shape but not value "
+                    f"constraints; using structured outputs anyway[/yellow]"
+                )
+        else:
             print(
-                "[yellow]ℹ Server doesn't support JSON schema, using delimiter method[/yellow]"
+                f"[yellow]ℹ '{model}' doesn't apply JSON schema ({verdict}), "
+                f"using delimiter method[/yellow]"
             )
 
     def rotate_key(self):
@@ -215,27 +362,50 @@ class ChatGPTAPI(Base):
         return messages
 
     def create_chat_completion(self, text):
+        """Plain (delimiter-mode) completion. Overridden by some subclasses."""
         messages = self.create_messages(text, self.create_context_messages())
 
-        if self._use_structured_outputs:
-            completion = self.openai_client.chat.completions.create(
+        return self.openai_client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+            extra_body=self.extra_body if self.extra_body else None,
+        )
+
+    def _structured_single_translation(self, text):
+        """Translate one paragraph via Structured Outputs.
+
+        Raises `StructuredOutputUnsupported` when the endpoint turns out not to
+        honor the schema, `LengthFinishReasonError` when the answer was cut off
+        (never returns the truncated JSON fragment), and `ValueError` on refusal.
+        """
+        messages = self.create_messages(text, self.create_context_messages())
+
+        try:
+            completion = self.openai_client.chat.completions.parse(
                 model=self.model,
                 messages=messages,
                 temperature=self.temperature,
-                response_format={
-                    "type": "json_schema",
-                    "json_schema": SINGLE_TRANSLATION_SCHEMA,
-                },
+                response_format=SingleTranslation,
                 extra_body=self.extra_body if self.extra_body else None,
             )
-        else:
-            completion = self.openai_client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                temperature=self.temperature,
-                extra_body=self.extra_body if self.extra_body else None,
-            )
-        return completion
+        except (BadRequestError, ValidationError, json.JSONDecodeError) as e:
+            # Rejected the schema, or answered with something that is not the
+            # schema — either way the capability is not there.
+            raise StructuredOutputUnsupported(str(e)) from e
+
+        message = completion.choices[0].message
+        if getattr(message, "refusal", None):
+            raise ValueError(f"Model refused to translate: {message.refusal}")
+        if message.parsed is None:
+            raise StructuredOutputUnsupported("no parsed content in response")
+
+        return message.parsed.translated
+
+    def _plain_translation(self, text):
+        completion = self.create_chat_completion(text)
+        content = completion.choices[0].message.content
+        return content.encode("utf8").decode() if content else ""
 
     @retry(
         stop=stop_after_attempt(3),
@@ -247,28 +417,14 @@ class ChatGPTAPI(Base):
         self.rotate_key()
         self.rotate_model()  # rotate all the model to avoid the limit
 
-        # Auto-detect if not yet tested
-        if self._use_structured_outputs is None:
-            self._test_structured_outputs()
-
-        completion = self.create_chat_completion(text)
-
-        # TODO work well or exception finish by length limit
-        # Check if content is not None before encoding
-        if completion.choices[0].message.content is not None:
-            t_text = completion.choices[0].message.content.encode("utf8").decode() or ""
-        else:
-            t_text = ""
-
-        # Parse structured output if enabled
-        if self._use_structured_outputs and t_text:
+        if self._ensure_structured_support():
             try:
-                parsed = json.loads(t_text)
-                t_text = parsed.get("translated", t_text)
-            except json.JSONDecodeError as e:
-                print(
-                    f"[yellow]Warning: Failed to parse structured output: {e}[/yellow]"
-                )
+                t_text = self._structured_single_translation(text)
+            except StructuredOutputUnsupported as e:
+                self._demote_structured_outputs(e)
+                t_text = self._plain_translation(text)
+        else:
+            t_text = self._plain_translation(text)
 
         if self.context_flag:
             self.save_context(text, t_text)
@@ -372,12 +528,8 @@ class ChatGPTAPI(Base):
         Priority: 1. Structured Outputs (strict) -> 2. Delimiter-based
         Returns a list of translated texts.
         """
-        # Auto-detect output mode on first use
-        if self._use_structured_outputs is None:
-            self._test_structured_outputs()
-
-        # Use structured outputs if available
-        if self._use_structured_outputs:
+        # Use structured outputs if available (probed once per model)
+        if self._ensure_structured_support():
             return self._do_structured_batch_translate(text_list)
 
         # Fallback to delimiter-based method
@@ -432,6 +584,10 @@ class ChatGPTAPI(Base):
         try:
             result = self._execute_structured_batch_translate(text_list, plist_len)
             return result
+        except StructuredOutputUnsupported as e:
+            # Capability answer, not a transient failure: stop paying for it.
+            self._demote_structured_outputs(e)
+            return [self.translate(t, False) for t in text_list]
         except Exception as e:
             print(
                 f"[yellow]Structured batch translation failed after retries: {e}. "
@@ -442,7 +598,7 @@ class ChatGPTAPI(Base):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=60),
-        retry=retry_if_exception_type((RateLimitError, Exception)),
+        retry=retry_if_not_exception_type(StructuredOutputUnsupported),
         reraise=True,
     )
     def _execute_structured_batch_translate(self, text_list, plist_len):
@@ -452,28 +608,26 @@ class ChatGPTAPI(Base):
 
         messages = self._create_structured_batch_messages(text_list)
 
-        completion = self.openai_client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            temperature=self.temperature,
-            response_format={
-                "type": "json_schema",
-                "json_schema": TRANSLATION_SCHEMA,
-            },
-            extra_body=self.extra_body if self.extra_body else None,
-        )
-
-        t_text = completion.choices[0].message.content.encode("utf8").decode() or ""
-
-        if not t_text:
-            raise ValueError("Structured output returned empty response")
-
         try:
-            parsed = json.loads(t_text)
-            paragraphs = parsed.get("paragraphs", [])
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Failed to parse structured batch output: {e}") from e
+            completion = self.openai_client.chat.completions.parse(
+                model=self.model,
+                messages=messages,
+                temperature=self.temperature,
+                response_format=BatchTranslation,
+                extra_body=self.extra_body if self.extra_body else None,
+            )
+        except (BadRequestError, ValidationError, json.JSONDecodeError) as e:
+            raise StructuredOutputUnsupported(str(e)) from e
 
+        message = completion.choices[0].message
+        if getattr(message, "refusal", None):
+            raise ValueError(f"Model refused to translate: {message.refusal}")
+        if message.parsed is None:
+            raise StructuredOutputUnsupported("no parsed content in response")
+
+        paragraphs = message.parsed.paragraphs
+
+        # A wrong count is a model error, not a capability answer: retry it.
         if len(paragraphs) != plist_len:
             raise ValueError(
                 f"Expected {plist_len} translations, got {len(paragraphs)}"
@@ -817,28 +971,39 @@ class ChatGPTAPI(Base):
             if line.strip():
                 result = json.loads(line)
                 if result["custom_id"] == custom_id:
-                    content = result["response"]["body"]["choices"][0]["message"][
-                        "content"
-                    ]
-
-                    # Parse JSON response if using structured outputs
-                    if self._use_structured_outputs:
-                        try:
-                            parsed = json.loads(content)
-                            if "translated" in parsed:
-                                return parsed["translated"]
-                            elif "paragraphs" in parsed:
-                                return (
-                                    parsed["paragraphs"][0]
-                                    if parsed["paragraphs"]
-                                    else content
-                                )
-                        except json.JSONDecodeError:
-                            return content  # Return as-is if parsing fails
-
-                    return content
+                    return self._read_batch_choice(
+                        result["response"]["body"]["choices"][0], custom_id
+                    )
 
         raise ValueError(f"No result found for custom_id {custom_id}")
+
+    @staticmethod
+    def _read_batch_choice(choice, custom_id):
+        """Unwrap one Batch API choice.
+
+        Results are often fetched by a later process that never probed the
+        model, so this decides from the payload itself rather than from cached
+        capability state — and refuses to hand back a truncated JSON fragment.
+        """
+        message = choice.get("message", {})
+        if message.get("refusal"):
+            raise ValueError(
+                f"Model refused to translate {custom_id}: {message['refusal']}"
+            )
+        if choice.get("finish_reason") == "length":
+            raise ValueError(
+                f"Batch result for {custom_id} was truncated by the token limit"
+            )
+
+        content = message.get("content") or ""
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            return content  # delimiter-mode batch, plain text is expected
+
+        if isinstance(parsed, dict) and isinstance(parsed.get("translated"), str):
+            return parsed["translated"]
+        return content
 
     def create_batch_context_messages(self, index):
         messages = []
@@ -882,8 +1047,9 @@ class ChatGPTAPI(Base):
             "temperature": self.temperature,
         }
 
-        # Add response format for batch requests if using structured outputs
-        if self._use_structured_outputs:
+        # The Batch API takes hand-built bodies, so the schema cannot come from
+        # the SDK here; SINGLE_TRANSLATION_SCHEMA mirrors SingleTranslation.
+        if self._ensure_structured_support(self.batch_model):
             batch_body["response_format"] = {
                 "type": "json_schema",
                 "json_schema": SINGLE_TRANSLATION_SCHEMA,

--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -13,6 +13,7 @@ from openai import (
     AuthenticationError,
     AzureOpenAI,
     BadRequestError,
+    LengthFinishReasonError,
     NotFoundError,
     OpenAI,
     PermissionDeniedError,
@@ -98,16 +99,30 @@ STRUCTURED_PROBE_SCHEMA = {
     },
 }
 
-# Errors that say nothing about JSON Schema support. Swallowing these would pin
-# the whole run to the delimiter method because of a bad key or a flaky network.
+# A permanent answer about this endpoint: no key, no access, no such model.
+# Nothing downstream recovers from these, and swallowing them would pin the whole
+# run to the delimiter method because of a typo in the key.
 PROBE_FATAL_ERRORS = (
     AuthenticationError,
     PermissionDeniedError,
+    NotFoundError,
+)
+
+# Router hiccups. These say nothing about schema support, but they also do not
+# mean the run is over: API gateways go away and come back, and a book is
+# expected to translate across hours of that. The probe therefore *defers* —
+# records no verdict, uses the delimiter method for this one call, and probes
+# again on the next paragraph. The real request behind it hits the same outage
+# and gets tenacity's retries, which is where transient failures belong.
+PROBE_TRANSIENT_ERRORS = (
     APIConnectionError,
     APITimeoutError,
     RateLimitError,
-    NotFoundError,
 )
+
+# One garbled response from a proxy must not cost the whole book its structured
+# mode. A genuinely unsupported endpoint still pays at most this many attempts.
+STRUCTURED_FAILURE_THRESHOLD = 2
 
 GPT35_MODEL_LIST = [
     "gpt-3.5-turbo",
@@ -221,6 +236,10 @@ class ChatGPTAPI(Base):
         # temperature support is learned from the first rejection.
         self._structured_support = {}
         self._temperature_unsupported = {}
+        # Consecutive capability failures per model, and models whose probe was
+        # postponed by an outage (tracked only to keep the log to one line).
+        self._structured_failures = {}
+        self._probe_deferred = set()
         self.model = (
             None  # Will be set by rotate_model() after model_list is initialized
         )
@@ -243,19 +262,52 @@ class ChatGPTAPI(Base):
     def _structured_enabled(self):
         return self._structured_support.get(self.model, False)
 
-    def _demote_structured_outputs(self, reason):
-        """Stop using structured outputs for this model after a real failure.
+    def _defer_probe(self, model, error):
+        """Postpone the verdict: record nothing so the next call probes again."""
+        with self._structured_lock:
+            first_time = model not in self._probe_deferred
+            self._probe_deferred.add(model)
+        if first_time:
+            print(
+                f"[yellow]ℹ could not probe '{model}' right now ({error}); "
+                f"using the delimiter method until the endpoint answers[/yellow]"
+            )
 
-        Without this, every later batch pays three tenacity attempts with
-        exponential backoff before falling back.
+    def _note_structured_success(self):
+        """A working structured call clears the model's failure streak."""
+        if self._structured_failures.get(self.model):
+            with self._structured_lock:
+                self._structured_failures.pop(self.model, None)
+
+    def _demote_structured_outputs(self, reason):
+        """Count a capability failure and, on a streak, stop paying for it.
+
+        The caller falls back for the current paragraph or batch either way. The
+        streak is what keeps a single garbled proxy response from disabling
+        structured outputs for the rest of a multi-hour run, while an endpoint
+        that really ignores the schema still costs only
+        `STRUCTURED_FAILURE_THRESHOLD` attempts instead of three tenacity
+        retries per batch, forever.
         """
         with self._structured_lock:
+            failures = self._structured_failures.get(self.model, 0) + 1
+            self._structured_failures[self.model] = failures
+            demote = failures >= STRUCTURED_FAILURE_THRESHOLD
             already_demoted = self._structured_support.get(self.model) is False
-            self._structured_support[self.model] = False
-        if not already_demoted:
+            if demote:
+                self._structured_support[self.model] = False
+
+        if demote:
+            if not already_demoted:
+                print(
+                    f"[yellow]ℹ '{self.model}' did not honor the JSON schema "
+                    f"({reason}); switching to the delimiter method[/yellow]"
+                )
+        else:
             print(
-                f"[yellow]ℹ '{self.model}' did not honor the JSON schema ({reason}); "
-                f"switching to the delimiter method[/yellow]"
+                f"[yellow]ℹ '{self.model}' did not honor the JSON schema "
+                f"({reason}); falling back for this one and trying structured "
+                f"outputs once more[/yellow]"
             )
 
     def _test_structured_outputs(self, model=None):
@@ -279,6 +331,9 @@ class ChatGPTAPI(Base):
             )
         except PROBE_FATAL_ERRORS:
             raise
+        except PROBE_TRANSIENT_ERRORS as e:
+            self._defer_probe(model, e)
+            return
         except Exception as e:
             # Ambiguous (400 for an unknown param, 500 from a local server, ...):
             # not a usable endpoint for schemas either way, so degrade loudly.
@@ -461,6 +516,7 @@ class ChatGPTAPI(Base):
         if message.parsed is None:
             raise StructuredOutputUnsupported("no parsed content in response")
 
+        self._note_structured_success()
         return message.parsed.translated
 
     def _plain_translation(self, text):
@@ -483,6 +539,15 @@ class ChatGPTAPI(Base):
                 t_text = self._structured_single_translation(text)
             except StructuredOutputUnsupported as e:
                 self._demote_structured_outputs(e)
+                t_text = self._plain_translation(text)
+            except LengthFinishReasonError:
+                # The answer was cut off mid-JSON. Nothing partial may be used,
+                # but the plain path has no JSON to truncate — retranslate there
+                # rather than ending a multi-hour run over one paragraph.
+                print(
+                    "[yellow]ℹ structured answer was truncated; retranslating "
+                    "this paragraph without a schema[/yellow]"
+                )
                 t_text = self._plain_translation(text)
         else:
             t_text = self._plain_translation(text)
@@ -704,6 +769,7 @@ class ChatGPTAPI(Base):
             for orig, trans in zip(text_list, paragraphs):
                 self.save_context(orig, trans)
 
+        self._note_structured_success()
         return paragraphs
 
     def set_deployment_id(self, deployment_id):

--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -165,7 +165,6 @@ class ChatGPTAPI(Base):
             self.openai_client.chat.completions.create(
                 model=self.model,
                 messages=test_messages,
-                temperature=0.1,
                 response_format={
                     "type": "json_schema",
                     "json_schema": SINGLE_TRANSLATION_SCHEMA,
@@ -680,7 +679,6 @@ class ChatGPTAPI(Base):
                 model=model_name,
                 messages=test_messages,
                 max_tokens=10,
-                temperature=0.1,
             )
             print(f"[green]Model '{model_name}' is accessible and working.[/green]")
         except Exception as e:

--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -80,6 +80,10 @@ SINGLE_TRANSLATION_SCHEMA = {
     },
 }
 
+# The API's own default. Sending it explicitly changes nothing for models that
+# accept it, and is a hard 400 for models that only allow their default.
+DEFAULT_TEMPERATURE = 1.0
+
 PROBE_PROMPT = "Reply with the single word: ignored. Do not output JSON."
 PROBE_KEY = "probe"
 PROBE_EXPECTED = "schema_ok"
@@ -212,9 +216,11 @@ class ChatGPTAPI(Base):
         self._structured_lock = RLock()
         self.extra_body = extra_body or {}
 
-        # Structured outputs: probed once per model on first use. Keyed by model
-        # because --model_list rotates across models of differing capability.
+        # Both keyed by model, because --model_list rotates across models of
+        # differing capability. Structured support is probed on first use;
+        # temperature support is learned from the first rejection.
         self._structured_support = {}
+        self._temperature_unsupported = {}
         self.model = (
             None  # Will be set by rotate_model() after model_list is initialized
         )
@@ -361,15 +367,65 @@ class ChatGPTAPI(Base):
             )
         return messages
 
+    def _sampling_kwargs(self, model=None):
+        """Sampling parameters to send, or nothing when the model owns them.
+
+        `DEFAULT_TEMPERATURE` is the API's own default, so sending it changes no
+        output — but gpt-5.x and the o-series reject *any* explicit temperature,
+        so an unrequested default is pure downside. A model that turned one down
+        is remembered and never asked again.
+        """
+        model = model or self.model
+        if self._temperature_unsupported.get(model):
+            return {}
+        if self.temperature is None or self.temperature == DEFAULT_TEMPERATURE:
+            return {}
+        return {"temperature": self.temperature}
+
+    @staticmethod
+    def _classify_bad_request(error):
+        """Say what a 400 was actually about: 'temperature', 'schema' or 'other'.
+
+        Without this, a temperature rejection is misread as "no schema support":
+        the model gets demoted for the rest of the run and the real cause never
+        reaches the user.
+        """
+        text = str(error).lower()
+        if "temperature" in text:
+            return "temperature"
+        if "response_format" in text or "json_schema" in text:
+            return "schema"
+        return "other"
+
+    def _request(self, call, model=None):
+        """Issue an API call, retrying once without temperature if refused."""
+        model = model or self.model
+        try:
+            return call(self._sampling_kwargs(model))
+        except BadRequestError as e:
+            if self._classify_bad_request(e) != "temperature":
+                raise
+            with self._structured_lock:
+                first_time = not self._temperature_unsupported.get(model)
+                self._temperature_unsupported[model] = True
+            if first_time:
+                print(
+                    f"[yellow]ℹ '{model}' rejected temperature={self.temperature}; "
+                    f"retrying with the model default[/yellow]"
+                )
+            return call({})
+
     def create_chat_completion(self, text):
         """Plain (delimiter-mode) completion. Overridden by some subclasses."""
         messages = self.create_messages(text, self.create_context_messages())
 
-        return self.openai_client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            temperature=self.temperature,
-            extra_body=self.extra_body if self.extra_body else None,
+        return self._request(
+            lambda sampling: self.openai_client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                extra_body=self.extra_body if self.extra_body else None,
+                **sampling,
+            )
         )
 
     def _structured_single_translation(self, text):
@@ -382,16 +438,21 @@ class ChatGPTAPI(Base):
         messages = self.create_messages(text, self.create_context_messages())
 
         try:
-            completion = self.openai_client.chat.completions.parse(
-                model=self.model,
-                messages=messages,
-                temperature=self.temperature,
-                response_format=SingleTranslation,
-                extra_body=self.extra_body if self.extra_body else None,
+            completion = self._request(
+                lambda sampling: self.openai_client.chat.completions.parse(
+                    model=self.model,
+                    messages=messages,
+                    response_format=SingleTranslation,
+                    extra_body=self.extra_body if self.extra_body else None,
+                    **sampling,
+                )
             )
-        except (BadRequestError, ValidationError, json.JSONDecodeError) as e:
-            # Rejected the schema, or answered with something that is not the
-            # schema — either way the capability is not there.
+        except BadRequestError as e:
+            if self._classify_bad_request(e) != "schema":
+                raise  # not a capability answer — do not blame the schema
+            raise StructuredOutputUnsupported(str(e)) from e
+        except (ValidationError, json.JSONDecodeError) as e:
+            # Answered with something that is not the schema.
             raise StructuredOutputUnsupported(str(e)) from e
 
         message = completion.choices[0].message
@@ -609,14 +670,20 @@ class ChatGPTAPI(Base):
         messages = self._create_structured_batch_messages(text_list)
 
         try:
-            completion = self.openai_client.chat.completions.parse(
-                model=self.model,
-                messages=messages,
-                temperature=self.temperature,
-                response_format=BatchTranslation,
-                extra_body=self.extra_body if self.extra_body else None,
+            completion = self._request(
+                lambda sampling: self.openai_client.chat.completions.parse(
+                    model=self.model,
+                    messages=messages,
+                    response_format=BatchTranslation,
+                    extra_body=self.extra_body if self.extra_body else None,
+                    **sampling,
+                )
             )
-        except (BadRequestError, ValidationError, json.JSONDecodeError) as e:
+        except BadRequestError as e:
+            if self._classify_bad_request(e) != "schema":
+                raise  # not a capability answer — do not blame the schema
+            raise StructuredOutputUnsupported(str(e)) from e
+        except (ValidationError, json.JSONDecodeError) as e:
             raise StructuredOutputUnsupported(str(e)) from e
 
         message = completion.choices[0].message
@@ -1044,7 +1111,7 @@ class ChatGPTAPI(Base):
         batch_body = {
             "model": self.batch_model,
             "messages": messages,
-            "temperature": self.temperature,
+            **self._sampling_kwargs(self.batch_model),
         }
 
         # The Batch API takes hand-built bodies, so the schema cannot come from

--- a/book_maker/translator/groq_translator.py
+++ b/book_maker/translator/groq_translator.py
@@ -12,6 +12,10 @@ GROQ_MODEL_LIST = [
 
 
 class GroqClient(ChatGPTAPI):
+    # Requests go through self.groq_client, not self.openai_client, so probing
+    # would send the capability request to OpenAI with a Groq key.
+    SUPPORTS_STRUCTURED_OUTPUTS = False
+
     def rotate_model(self):
         if not self.model_list:
             model_list = list(set(GROQ_MODEL_LIST))

--- a/book_maker/translator/litellm_translator.py
+++ b/book_maker/translator/litellm_translator.py
@@ -11,6 +11,9 @@ PROMPT_ENV_MAP = {
 
 
 class liteLLM(ChatGPTAPI):
+    # Routed through litellm's own completion(), not self.openai_client.
+    SUPPORTS_STRUCTURED_OUTPUTS = False
+
     def create_chat_completion(self, text):
         # content = self.prompt_template.format(
         #     text=text, language=self.language, crlf="\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dependencies = [
     "ebooklib",
     "google-genai",
     "litellm",
-    "openai>=1.1.1",
+    # chat.completions.parse (Structured Outputs) is unavailable before 1.92.
+    "openai>=1.92.0",
+    "pydantic>=2.0",
     "PyDeepLX",
     "requests",
     "rich",

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from book_maker.translator.chatgptapi_translator import ChatGPTAPI
+
+
+def _completion(content):
+    message = SimpleNamespace(content=content)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _translator(create):
+    translator = ChatGPTAPI.__new__(ChatGPTAPI)
+    translator.model = "test-model"
+    translator._use_structured_outputs = None
+    translator.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=create),
+        )
+    )
+    return translator
+
+
+def test_structured_output_probe_uses_only_capability_parameters():
+    create = Mock(return_value=_completion('{"translated":"test"}'))
+    translator = _translator(create)
+
+    translator._test_structured_outputs()
+
+    assert translator._use_structured_outputs is True
+    request = create.call_args.kwargs
+    assert "temperature" not in request
+    assert request["response_format"]["type"] == "json_schema"
+
+
+def test_structured_output_probe_falls_back_when_schema_is_rejected():
+    translator = _translator(Mock(side_effect=Exception("unsupported response_format")))
+
+    translator._test_structured_outputs()
+
+    assert translator._use_structured_outputs is False
+
+
+def test_model_validation_probe_uses_model_defaults():
+    create = Mock(return_value=_completion("ok"))
+    translator = _translator(create)
+
+    translator._validate_model_with_test("test-model", "Test")
+
+    request = create.call_args.kwargs
+    assert request["model"] == "test-model"
+    assert request["max_tokens"] == 10
+    assert "temperature" not in request

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -9,9 +9,12 @@ import httpx
 import pytest
 from openai import (
     APIConnectionError,
+    APITimeoutError,
     AuthenticationError,
     BadRequestError,
     LengthFinishReasonError,
+    NotFoundError,
+    RateLimitError,
 )
 
 from book_maker.translator.chatgptapi_translator import (
@@ -62,6 +65,8 @@ def _translator(create=None, parse=None, cls=ChatGPTAPI):
     translator._structured_lock = threading.RLock()
     translator._structured_support = {}
     translator._temperature_unsupported = {}
+    translator._structured_failures = {}
+    translator._probe_deferred = set()
     translator.openai_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
@@ -179,18 +184,61 @@ def test_probe_treats_bad_request_as_no_schema_support():
     "error",
     [
         _api_error(AuthenticationError, 401),
-        APIConnectionError(
-            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
-        ),
+        _api_error(NotFoundError, 404),
     ],
 )
-def test_probe_reraises_errors_that_are_not_capability_answers(error):
+def test_probe_reraises_permanent_endpoint_errors(error):
+    """A bad key or a wrong model name must not read as 'no schema support'."""
     translator = _translator(create=Mock(side_effect=error))
 
     with pytest.raises(type(error)):
         translator._test_structured_outputs()
 
     assert translator._structured_support == {}
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        APIConnectionError(
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        ),
+        APITimeoutError(
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        ),
+        _api_error(RateLimitError, 429),
+    ],
+)
+def test_probe_defers_on_a_router_outage_instead_of_ending_the_run(error):
+    """Gateways come back. A blip must not raise and must not cache a verdict."""
+    translator = _translator(create=Mock(side_effect=error))
+
+    assert translator._ensure_structured_support() is False
+    assert translator._structured_support == {}  # nothing learned, nothing cached
+
+
+def test_deferred_probe_is_retried_on_the_next_paragraph():
+    outage = APIConnectionError(
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    )
+    create = Mock(side_effect=[outage, _completion('{"probe":"schema_ok"}')])
+    translator = _translator(create=create)
+
+    assert translator._ensure_structured_support() is False
+    assert translator._ensure_structured_support() is True
+    assert create.call_count == 2
+
+
+def test_translate_list_survives_a_probe_outage():
+    """`translate_list` probes outside any tenacity wrapper, so a blip there
+    used to take down the run with zero retries."""
+    outage = APIConnectionError(
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    )
+    translator = _translator(create=Mock(side_effect=outage))
+    translator._do_batch_translate = Mock(return_value=["t:a", "t:b"])
+
+    assert translator.translate_list(["a", "b"]) == ["t:a", "t:b"]
 
 
 def test_probe_falls_back_on_ambiguous_server_error():
@@ -279,6 +327,30 @@ def test_truncated_response_raises_instead_of_leaking_json_fragment():
         translator._structured_single_translation("hello")
 
 
+def test_truncation_retranslates_plainly_instead_of_ending_the_run():
+    """No partial JSON in the book, but no dead run either: the plain path has
+    no JSON to truncate, so one long paragraph goes through it."""
+    error = LengthFinishReasonError(
+        completion=SimpleNamespace(
+            usage=None,
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content='{"translated":"半'),
+                    finish_reason="length",
+                )
+            ],
+        )
+    )
+    create = Mock(return_value=_completion("完整的翻譯"))
+    translator = _translator(create=create, parse=Mock(side_effect=error))
+    translator._structured_support["test-model"] = True
+
+    assert translator.get_translation("hello") == "完整的翻譯"
+    assert create.call_count == 1
+    # Truncation is a token-budget accident, not a capability answer.
+    assert translator._structured_support["test-model"] is True
+
+
 def test_refusal_raises_loudly():
     translator = _translator(
         parse=Mock(return_value=_parsed_completion(refusal="nope"))
@@ -300,10 +372,34 @@ def test_single_path_demotes_and_retries_plainly_when_schema_is_ignored():
     translator = _translator(create=create, parse=parse)
     translator._structured_support["test-model"] = True
 
+    # First failure falls back for this paragraph but keeps structured mode on:
+    # one garbled proxy answer must not cost a whole book its schema support.
+    assert translator.get_translation("hello") == "plain translation"
+    assert translator._structured_support["test-model"] is True
+
     assert translator.get_translation("hello") == "plain translation"
     assert translator._structured_support["test-model"] is False
-    assert parse.call_count == 1
-    assert create.call_count == 1
+
+    assert parse.call_count == 2
+    assert create.call_count == 2
+
+
+def test_a_working_structured_call_clears_the_failure_streak():
+    parse = Mock(
+        side_effect=[
+            StructuredOutputUnsupported("blip"),
+            _parsed_completion(parsed=SimpleNamespace(translated="你好")),
+            StructuredOutputUnsupported("blip"),
+        ]
+    )
+    translator = _translator(parse=parse)
+    translator._structured_support["test-model"] = True
+
+    translator.get_translation("a")  # streak 1
+    assert translator.get_translation("b") == "你好"  # streak reset
+    translator.get_translation("c")  # streak 1 again, not 2
+
+    assert translator._structured_support["test-model"] is True
 
 
 def test_batch_path_demotes_without_burning_retries():
@@ -312,10 +408,10 @@ def test_batch_path_demotes_without_burning_retries():
     translator._structured_support["test-model"] = True
     translator.translate = Mock(side_effect=lambda text, _=True: f"t:{text}")
 
-    result = translator._do_structured_batch_translate(["a", "b"])
+    assert translator._do_structured_batch_translate(["a", "b"]) == ["t:a", "t:b"]
+    assert translator._do_structured_batch_translate(["a", "b"]) == ["t:a", "t:b"]
 
-    assert result == ["t:a", "t:b"]
-    assert parse.call_count == 1  # not 3 tenacity attempts
+    assert parse.call_count == 2  # one attempt each, not 3 tenacity attempts
     assert translator._structured_support["test-model"] is False
 
 

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -37,10 +37,10 @@ def _parsed_completion(parsed=None, refusal=None):
     )
 
 
-def _api_error(cls, status_code):
+def _api_error(cls, status_code, message="boom"):
     request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
     response = httpx.Response(status_code, request=request)
-    return cls("boom", response=response, body=None)
+    return cls(message, response=response, body=None)
 
 
 def _translator(create=None, parse=None, cls=ChatGPTAPI):
@@ -61,6 +61,7 @@ def _translator(create=None, parse=None, cls=ChatGPTAPI):
     translator._api_lock = threading.Lock()
     translator._structured_lock = threading.RLock()
     translator._structured_support = {}
+    translator._temperature_unsupported = {}
     translator.openai_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
@@ -361,6 +362,157 @@ def test_groq_never_probes_for_structured_outputs():
     assert GroqClient.SUPPORTS_STRUCTURED_OUTPUTS is False
     assert translator._structured_support["test-model"] is False
     assert create.call_count == 0
+
+
+# --------------------------------------------------------------------------
+# Item 6: temperature must not be forced onto models that only accept their
+# default, and a temperature 400 must not be blamed on the JSON schema
+# --------------------------------------------------------------------------
+
+
+def test_default_temperature_is_not_sent():
+    """1.0 is the API default, so sending it is a no-op — except on models that
+    reject any explicit temperature."""
+    parse = Mock(
+        return_value=_parsed_completion(parsed=SimpleNamespace(translated="你好"))
+    )
+    translator = _translator(parse=parse)
+    translator.temperature = 1.0
+    translator._structured_support["test-model"] = True
+
+    translator._structured_single_translation("hello")
+
+    assert "temperature" not in parse.call_args.kwargs
+
+
+def test_explicit_temperature_is_sent():
+    parse = Mock(
+        return_value=_parsed_completion(parsed=SimpleNamespace(translated="你好"))
+    )
+    translator = _translator(parse=parse)
+    translator.temperature = 0.1
+    translator._structured_support["test-model"] = True
+
+    translator._structured_single_translation("hello")
+
+    assert parse.call_args.kwargs["temperature"] == 0.1
+
+
+def test_plain_path_also_honors_the_default_temperature_rule():
+    create = Mock(return_value=_completion("plain"))
+    translator = _translator(create=create)
+    translator.temperature = 1.0
+
+    translator.create_chat_completion("hello")
+
+    assert "temperature" not in create.call_args.kwargs
+
+
+def test_temperature_rejection_retries_once_without_it_and_is_cached():
+    ok = _parsed_completion(parsed=SimpleNamespace(translated="你好"))
+    parse = Mock(
+        side_effect=[
+            _api_error(
+                BadRequestError,
+                400,
+                "Unsupported value: 'temperature' does not support 0.1 with this model",
+            ),
+            ok,
+            ok,
+        ]
+    )
+    translator = _translator(parse=parse)
+    translator.temperature = 0.1
+    translator._structured_support["test-model"] = True
+
+    assert translator._structured_single_translation("hello") == "你好"
+    assert parse.call_count == 2
+    assert "temperature" not in parse.call_args.kwargs
+    assert translator._temperature_unsupported["test-model"] is True
+
+    # Cached: the second translation never sends it again.
+    translator._structured_single_translation("world")
+    assert parse.call_count == 3
+    assert "temperature" not in parse.call_args.kwargs
+
+
+def test_temperature_rejection_does_not_demote_structured_outputs():
+    ok = _parsed_completion(parsed=SimpleNamespace(translated="你好"))
+    parse = Mock(
+        side_effect=[
+            _api_error(BadRequestError, 400, "temperature is not supported"),
+            ok,
+        ]
+    )
+    translator = _translator(parse=parse)
+    translator.temperature = 0.1
+    translator._structured_support["test-model"] = True
+
+    translator._structured_single_translation("hello")
+
+    assert translator._structured_support["test-model"] is True
+
+
+def test_schema_rejection_is_still_a_capability_answer():
+    parse = Mock(
+        side_effect=_api_error(
+            BadRequestError, 400, "response_format of type json_schema is not supported"
+        )
+    )
+    translator = _translator(parse=parse)
+    translator._structured_support["test-model"] = True
+
+    with pytest.raises(StructuredOutputUnsupported):
+        translator._structured_single_translation("hello")
+
+
+def test_unrelated_bad_request_is_not_blamed_on_the_schema():
+    parse = Mock(
+        side_effect=_api_error(BadRequestError, 400, "context length exceeded")
+    )
+    translator = _translator(parse=parse)
+    translator._structured_support["test-model"] = True
+
+    with pytest.raises(BadRequestError):
+        translator._structured_single_translation("hello")
+
+    # Still enabled: the model never said anything about schemas.
+    assert translator._structured_support["test-model"] is True
+
+
+def test_batch_path_applies_the_same_temperature_rule():
+    parse = Mock(
+        return_value=_parsed_completion(parsed=SimpleNamespace(paragraphs=["一", "二"]))
+    )
+    translator = _translator(parse=parse)
+    translator.temperature = 1.0
+    translator._structured_support["test-model"] = True
+
+    translator._do_structured_batch_translate(["a", "b"])
+
+    assert "temperature" not in parse.call_args.kwargs
+
+
+def test_temperature_support_is_tracked_per_model():
+    translator = _translator()
+    translator.temperature = 0.1
+    translator._temperature_unsupported["test-model"] = True
+
+    assert translator._sampling_kwargs() == {}
+    assert translator._sampling_kwargs("other-model") == {"temperature": 0.1}
+
+
+def test_batch_api_body_omits_default_temperature():
+    translator = _translator()
+    translator.temperature = 1.0
+    translator.batch_model = "batch-model"
+    translator._structured_support["batch-model"] = False
+    translator.create_batch_context_messages = Mock(return_value=[])
+    translator.custom_id = Mock(return_value="id-1")
+
+    body = translator.make_batch_request(0, "hello")["body"]
+
+    assert "temperature" not in body
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -1,49 +1,414 @@
+import json
+import threading
+import time
+from itertools import cycle
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-from book_maker.translator.chatgptapi_translator import ChatGPTAPI
+import httpx
+import pytest
+from openai import (
+    APIConnectionError,
+    AuthenticationError,
+    BadRequestError,
+    LengthFinishReasonError,
+)
+
+from book_maker.translator.chatgptapi_translator import (
+    ChatGPTAPI,
+    StructuredOutputUnsupported,
+)
+from book_maker.translator.groq_translator import GroqClient
 
 
-def _completion(content):
+def _completion(content, finish_reason="stop"):
+    """Raw `.create` style completion (probe / plain path)."""
     message = SimpleNamespace(content=content)
-    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)]
+    )
 
 
-def _translator(create):
-    translator = ChatGPTAPI.__new__(ChatGPTAPI)
+def _parsed_completion(parsed=None, refusal=None):
+    """`.parse` style completion: exposes `.parsed` and `.refusal`."""
+    message = SimpleNamespace(parsed=parsed, refusal=refusal, content=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")]
+    )
+
+
+def _api_error(cls, status_code):
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(status_code, request=request)
+    return cls("boom", response=response, body=None)
+
+
+def _translator(create=None, parse=None, cls=ChatGPTAPI):
+    translator = cls.__new__(cls)
     translator.model = "test-model"
-    translator._use_structured_outputs = None
+    translator.model_list = None
+    translator.keys = cycle(["k"])
+    translator.temperature = 1.0
+    translator.extra_body = {}
+    translator.context_flag = False
+    translator.context_list = []
+    translator.context_translated_list = []
+    translator.context_paragraph_limit = 0
+    translator.system_content = ""
+    translator.prompt_sys_msg = ""
+    translator.prompt_template = ChatGPTAPI.DEFAULT_PROMPT
+    translator.language = "Chinese"
+    translator._api_lock = threading.Lock()
+    translator._structured_lock = threading.RLock()
+    translator._structured_support = {}
     translator.openai_client = SimpleNamespace(
         chat=SimpleNamespace(
-            completions=SimpleNamespace(create=create),
+            completions=SimpleNamespace(
+                create=create or Mock(return_value=_completion("plain")),
+                parse=parse or Mock(return_value=_parsed_completion()),
+            ),
         )
     )
     return translator
 
 
-def test_structured_output_probe_uses_only_capability_parameters():
-    create = Mock(return_value=_completion('{"translated":"test"}'))
-    translator = _translator(create)
+# --------------------------------------------------------------------------
+# Item 1: the probe must grade the response body, not the absence of an error
+# --------------------------------------------------------------------------
+
+
+def test_probe_asks_for_non_json_while_pinning_the_schema():
+    create = Mock(return_value=_completion('{"probe":"schema_ok"}'))
+    translator = _translator(create=create)
 
     translator._test_structured_outputs()
 
-    assert translator._use_structured_outputs is True
+    request = create.call_args.kwargs
+    # The prompt must fight the schema: a relaying proxy yields plain text.
+    assert "json" in request["messages"][0]["content"].lower()
+    schema = request["response_format"]["json_schema"]
+    assert request["response_format"]["type"] == "json_schema"
+    assert schema["strict"] is True
+    # Single-value enum: constrained decoding has exactly one legal output, and
+    # that value never appears in the prompt.
+    assert schema["schema"]["properties"]["probe"]["enum"] == ["schema_ok"]
+    assert "schema_ok" not in request["messages"][0]["content"]
+
+
+def test_probe_sends_no_temperature_and_no_token_cap():
+    create = Mock(return_value=_completion('{"probe":"schema_ok"}'))
+    translator = _translator(create=create)
+
+    translator._test_structured_outputs()
+
     request = create.call_args.kwargs
     assert "temperature" not in request
-    assert request["response_format"]["type"] == "json_schema"
+    # A cap is rejected by o-series/gpt-5 and eaten by reasoning tokens.
+    assert "max_tokens" not in request
+    assert "max_completion_tokens" not in request
 
 
-def test_structured_output_probe_falls_back_when_schema_is_rejected():
-    translator = _translator(Mock(side_effect=Exception("unsupported response_format")))
+def test_probe_accepts_exact_constrained_value():
+    translator = _translator(
+        create=Mock(return_value=_completion('{"probe":"schema_ok"}'))
+    )
 
     translator._test_structured_outputs()
 
-    assert translator._use_structured_outputs is False
+    assert translator._structured_support["test-model"] is True
+
+
+def test_probe_accepts_correct_shape_with_wrong_value():
+    """Servers that honor structure but ignore `enum` are still usable."""
+    translator = _translator(
+        create=Mock(return_value=_completion('{"probe":"ignored"}'))
+    )
+
+    translator._test_structured_outputs()
+
+    assert translator._structured_support["test-model"] is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "ignored",  # proxy dropped response_format entirely
+        '```json\n{"probe":"schema_ok"}\n```',  # fenced, not raw JSON
+        '{"probe":"schema_ok","extra":1}',  # additionalProperties not enforced
+        '{"answer":"ignored"}',  # json mode only, schema ignored
+        '{"probe":42}',  # wrong type
+        "[1,2,3]",  # not an object
+        "",  # empty body
+    ],
+)
+def test_probe_rejects_servers_that_do_not_apply_the_schema(content):
+    translator = _translator(create=Mock(return_value=_completion(content)))
+
+    translator._test_structured_outputs()
+
+    assert translator._structured_support["test-model"] is False
+
+
+def test_probe_rejects_truncated_probe_response():
+    translator = _translator(
+        create=Mock(
+            return_value=_completion('{"probe":"schema', finish_reason="length")
+        )
+    )
+
+    translator._test_structured_outputs()
+
+    assert translator._structured_support["test-model"] is False
+
+
+# --------------------------------------------------------------------------
+# Item 5: only capability answers may be swallowed
+# --------------------------------------------------------------------------
+
+
+def test_probe_treats_bad_request_as_no_schema_support():
+    translator = _translator(create=Mock(side_effect=_api_error(BadRequestError, 400)))
+
+    translator._test_structured_outputs()
+
+    assert translator._structured_support["test-model"] is False
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _api_error(AuthenticationError, 401),
+        APIConnectionError(
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        ),
+    ],
+)
+def test_probe_reraises_errors_that_are_not_capability_answers(error):
+    translator = _translator(create=Mock(side_effect=error))
+
+    with pytest.raises(type(error)):
+        translator._test_structured_outputs()
+
+    assert translator._structured_support == {}
+
+
+def test_probe_falls_back_on_ambiguous_server_error():
+    """A 500 from a quirky local server must degrade, not crash the run."""
+
+    class WeirdServerError(Exception):
+        pass
+
+    translator = _translator(create=Mock(side_effect=WeirdServerError("boom")))
+
+    translator._test_structured_outputs()
+
+    assert translator._structured_support["test-model"] is False
+
+
+# --------------------------------------------------------------------------
+# Item 1 (cont.): cache is per model and probed once under the lock
+# --------------------------------------------------------------------------
+
+
+def test_support_is_cached_per_model():
+    create = Mock(return_value=_completion('{"probe":"schema_ok"}'))
+    translator = _translator(create=create)
+
+    translator._ensure_structured_support()
+    translator._ensure_structured_support()
+    assert create.call_count == 1
+
+    translator.model = "other-model"
+    translator._ensure_structured_support()
+    assert create.call_count == 2
+    assert set(translator._structured_support) == {"test-model", "other-model"}
+
+
+def test_concurrent_workers_probe_a_model_only_once():
+    def slow_create(**kwargs):
+        time.sleep(0.05)  # wide enough for unsynchronized workers to pile in
+        return _completion('{"probe":"schema_ok"}')
+
+    create = Mock(side_effect=slow_create)
+    translator = _translator(create=create)
+
+    threads = [
+        threading.Thread(target=translator._ensure_structured_support) for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert create.call_count == 1
+
+
+# --------------------------------------------------------------------------
+# Item 2 + 7: parse-based single translation must never leak broken JSON
+# --------------------------------------------------------------------------
+
+
+def test_single_translation_returns_parsed_field():
+    parse = Mock(
+        return_value=_parsed_completion(parsed=SimpleNamespace(translated="你好"))
+    )
+    translator = _translator(parse=parse)
+    translator._structured_support["test-model"] = True
+
+    assert translator.get_translation("hello") == "你好"
+    assert parse.call_args.kwargs["response_format"].__name__ == "SingleTranslation"
+
+
+def test_truncated_response_raises_instead_of_leaking_json_fragment():
+    error = LengthFinishReasonError(
+        completion=SimpleNamespace(
+            usage=None,
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content='{"translated":"半'),
+                    finish_reason="length",
+                )
+            ],
+        )
+    )
+    translator = _translator(parse=Mock(side_effect=error))
+    translator._structured_support["test-model"] = True
+
+    with pytest.raises(LengthFinishReasonError):
+        translator._structured_single_translation("hello")
+
+
+def test_refusal_raises_loudly():
+    translator = _translator(
+        parse=Mock(return_value=_parsed_completion(refusal="nope"))
+    )
+    translator._structured_support["test-model"] = True
+
+    with pytest.raises(ValueError, match="refused"):
+        translator._structured_single_translation("hello")
+
+
+# --------------------------------------------------------------------------
+# Item 1 (cont.): demote on the first real structured failure
+# --------------------------------------------------------------------------
+
+
+def test_single_path_demotes_and_retries_plainly_when_schema_is_ignored():
+    parse = Mock(side_effect=StructuredOutputUnsupported("server ignored schema"))
+    create = Mock(return_value=_completion("plain translation"))
+    translator = _translator(create=create, parse=parse)
+    translator._structured_support["test-model"] = True
+
+    assert translator.get_translation("hello") == "plain translation"
+    assert translator._structured_support["test-model"] is False
+    assert parse.call_count == 1
+    assert create.call_count == 1
+
+
+def test_batch_path_demotes_without_burning_retries():
+    parse = Mock(side_effect=StructuredOutputUnsupported("server ignored schema"))
+    translator = _translator(parse=parse)
+    translator._structured_support["test-model"] = True
+    translator.translate = Mock(side_effect=lambda text, _=True: f"t:{text}")
+
+    result = translator._do_structured_batch_translate(["a", "b"])
+
+    assert result == ["t:a", "t:b"]
+    assert parse.call_count == 1  # not 3 tenacity attempts
+    assert translator._structured_support["test-model"] is False
+
+
+def test_batch_length_mismatch_is_retried_then_falls_back_one_by_one():
+    parse = Mock(
+        return_value=_parsed_completion(parsed=SimpleNamespace(paragraphs=["only one"]))
+    )
+    translator = _translator(parse=parse)
+    translator._structured_support["test-model"] = True
+    translator.translate = Mock(side_effect=lambda text, _=True: f"t:{text}")
+
+    result = translator._do_structured_batch_translate(["a", "b"])
+
+    assert result == ["t:a", "t:b"]
+    assert parse.call_count == 3  # a model error, not a capability answer
+    # A count mismatch says nothing about schema support.
+    assert translator._structured_support["test-model"] is True
+
+
+def test_batch_success_returns_paragraphs():
+    parse = Mock(
+        return_value=_parsed_completion(parsed=SimpleNamespace(paragraphs=["一", "二"]))
+    )
+    translator = _translator(parse=parse)
+    translator._structured_support["test-model"] = True
+
+    assert translator._do_structured_batch_translate(["a", "b"]) == ["一", "二"]
+    request = parse.call_args.kwargs
+    assert request["response_format"].__name__ == "BatchTranslation"
+    assert json.loads  # payload is built by the SDK, not hand-rolled
+
+
+# --------------------------------------------------------------------------
+# Subclasses that do not route through openai_client must not be probed
+# --------------------------------------------------------------------------
+
+
+def test_groq_never_probes_for_structured_outputs():
+    create = Mock(return_value=_completion("plain"))
+    translator = _translator(create=create, cls=GroqClient)
+
+    translator._ensure_structured_support()
+
+    assert GroqClient.SUPPORTS_STRUCTURED_OUTPUTS is False
+    assert translator._structured_support["test-model"] is False
+    assert create.call_count == 0
+
+
+# --------------------------------------------------------------------------
+# Item 2, Batch API flavour: results are read by a later process that never
+# probed, so the payload itself must decide
+# --------------------------------------------------------------------------
+
+
+def test_batch_choice_unwraps_structured_content_without_cached_state():
+    choice = {
+        "finish_reason": "stop",
+        "message": {"content": '{"translated":"你好"}'},
+    }
+
+    assert ChatGPTAPI._read_batch_choice(choice, "id-1") == "你好"
+
+
+def test_batch_choice_passes_through_plain_content():
+    choice = {"finish_reason": "stop", "message": {"content": "plain text"}}
+
+    assert ChatGPTAPI._read_batch_choice(choice, "id-1") == "plain text"
+
+
+def test_batch_choice_rejects_truncated_result():
+    choice = {
+        "finish_reason": "length",
+        "message": {"content": '{"translated":"半'},
+    }
+
+    with pytest.raises(ValueError, match="truncated"):
+        ChatGPTAPI._read_batch_choice(choice, "id-1")
+
+
+def test_batch_choice_rejects_refusal():
+    choice = {"finish_reason": "stop", "message": {"refusal": "nope", "content": None}}
+
+    with pytest.raises(ValueError, match="refused"):
+        ChatGPTAPI._read_batch_choice(choice, "id-1")
+
+
+# --------------------------------------------------------------------------
+# Unrelated probe, kept from before
+# --------------------------------------------------------------------------
 
 
 def test_model_validation_probe_uses_model_defaults():
     create = Mock(return_value=_completion("ok"))
-    translator = _translator(create)
+    translator = _translator(create=create)
 
     translator._validate_model_with_test("test-model", "Test")
 


### PR DESCRIPTION
## 概要

原本的 Structured Outputs 探测只判断「请求有没有抛异常」，并不检查返回内容。很多 OpenAI 兼容的代理／自建端点会接受 `response_format` 却直接忽略它，于是这些端点会通过探测，然后每一次真实请求都失败——每批要先耗掉 3 次 tenacity 重试（指数退避）才退回逐段翻译。

这个 PR 在原有「探测不再强制 `temperature=0.1`」的基础上，把整条结构化输出链路补齐。

## 改动内容

### 1. 探测改为对抗式，并检查返回内容

提示词要求模型输出纯文本，schema 却用单值 `enum` 把结果钉死：

```python
PROBE_PROMPT = "Reply with the single word: ignored. Do not output JSON."
STRUCTURED_PROBE_SCHEMA = {..., "probe": {"type": "string", "enum": ["schema_ok"]}}
```

`"schema_ok"` 从未出现在提示词里，只有 schema 真正作用到解码阶段才可能返回它。丢弃 `response_format` 的服务器会回 `ignored`；只支持 json mode 的服务器会回合法 JSON 但键名随意。两者都判不通过。

`_grade_probe_response` 给出三种结论：

| 返回 | 结论 | 使用模式 |
|---|---|---|
| `{"probe":"schema_ok"}` | `strict` | 结构化输出 |
| `{"probe":"<其它值>"}` | `shape` | 结构化输出（记录日志：尊重结构但忽略 `enum`） |
| 纯文本、带 ``` 包裹的 JSON、多余或错误的键、非对象、`finish_reason != stop` | `unsupported` | 分隔符模式 |

保留 `shape` 是为了避免误判：部分后端实现了结构约束但不实现值约束，而本项目的 schema 本来就只约束结构。

探测依旧不带 temperature，也**不加** token 上限——上限会被 o 系列／gpt-5 直接拒绝（它们要 `max_completion_tokens`），也会被推理 token 吃光而在输出任何内容前截断，两种情况都会被误读成「不支持 schema」。

### 2. 区分「能力答复」和「其它错误」

原来的 `except Exception` 会把坏 key、DNS 抖动、模型名写错，全都变成「服务器不支持 JSON schema」，并把整个进程钉死在分隔符模式。

现在 `AuthenticationError`、`PermissionDeniedError`、`APIConnectionError`、`APITimeoutError`、`RateLimitError`、`NotFoundError` 一律向上抛。其余错误（包括未知参数的 400、本地服务器的 5xx）才降级，并打印具体错误。这里没有只放行 `BadRequestError`，否则 llama.cpp 这类「遇到未知参数返回 500」的服务器会直接让整个任务崩掉。

### 3. 真实请求改用 `chat.completions.parse` + Pydantic

`SingleTranslation` / `BatchTranslation` 取代手写 schema 字典和手动 `json.loads`，由 SDK 提供 `.parsed`、`.refusal` 和 `LengthFinishReasonError`。

这修掉了一个会污染译文的 bug：原先单段路径在 `JSONDecodeError` 时保持 `t_text` 不变，于是被截断的 `{"translated": "半` 会被当成译文写进书里。现在截断和拒答都会抛错。

`create_chat_completion` 收窄为仅负责非结构化路径，保留 `GroqClient`、`liteLLM` 依赖的覆写接口。

### 4. 按模型缓存 + 首次失败即降级

`_use_structured_outputs: bool` 改为 `_structured_support: dict[model, bool]`。原来一个布尔值会套用到 `--model_list` 里的所有模型，而且读写都在 `_api_lock` 之外，`--parallel-workers N` 会并发触发 N 次探测。现在探测在可重入锁内完成，每个模型只探一次。

`_demote_structured_outputs()` 在首次出现 `StructuredOutputUnsupported` 时永久关闭该模型的结构化输出，批量执行器用 `retry_if_not_exception_type` 把它排除在重试之外。段落数量对不上**不算**降级条件——那是模型问题，仍然按原逻辑重试后逐段回退。

### 5. 不再强制 temperature，并且不再把 400 一律算在 schema 头上

`temperature=1.0` 就是 API 自身的默认值，显式发送它对接受它的模型毫无影响，却会让 gpt-5.x 和 o 系列直接 400（这些模型只允许默认值）。因此 `_sampling_kwargs()` 只在用户指定了非默认值时才带上该参数，默认情况下任何模型都能跑通。

如果用户确实传了 `--temperature 0.1` 而模型拒绝，`_request()` 会去掉该参数重试一次，并记住这个模型，代价是每个模型每次运行最多一个 400，而不是整个任务失败。

`_classify_bad_request()` 负责区分 400 到底是 `temperature`、`schema` 还是其它原因。这一点很关键：改用 `chat.completions.parse` 的第一版把 `BadRequestError` 一律转成 `StructuredOutputUnsupported`，于是 temperature 被拒会被报成「该模型不支持 JSON schema」，把模型永久降级，接着非结构化回退又用同样的 temperature 再失败一次，真正的原因始终没有暴露出来。现在只有 schema 类 400 才降级，其余向上抛。

范围限定在 OpenAI 端点：`cli.py` 的 `--temperature` 同时也传给 Claude 和 Gemini 的 translator，本 PR 不动它们。

### 6. Batch API 与子类

- `/v1/batches` 的 JSONL 请求体是手工拼的，因此保留 `SINGLE_TRANSLATION_SCHEMA` 作为 `SingleTranslation` 的镜像。`_read_batch_choice` 依据返回内容本身判断是否需要解包，而不依赖缓存的探测状态——batch 结果通常由后续另一个进程取回，那个进程从未探测过；同时在 `finish_reason == "length"` 或拒答时直接抛错，不再返回残缺 JSON。
- `GroqClient` 和 `liteLLM` 设置 `SUPPORTS_STRUCTURED_OUTPUTS = False`：两者都覆写了 `create_chat_completion` 且不经过 `self.openai_client`，探测它们等于拿着 Groq/litellm 的 key 去请求 api.openai.com。此前是被那个 `except Exception` 掩盖掉的，改了错误分类后会直接崩。`XAIClient` 正确设置了 `openai_client`，保持启用。
- `pyproject.toml` 的下限提到 `openai>=1.92.0`（`chat.completions.parse` 在原先声明的 `>=1.1.1` 里并不存在），并显式声明 `pydantic>=2.0`。

## 验证

- `pytest tests/test_chatgptapi_translator.py` — **48 passed**：探测评级矩阵（7 种拒绝场景）、致命／瞬时／能力三类错误的区分、推迟后重新探测、`translate_list` 在故障中存活、按模型缓存、4 线程只探测一次、拒答、截断回退、连续失败降级与计数清零、Groq 退出、batch 结果读取、temperature 的省略／重试／400 分类。
- `pytest` — **106 passed, 3 failed, 3 skipped**。同一棵树改动前的基线是 60 passed / 4 failed；剩下 3 个失败都是已知的环境问题（PyDeepLX/httpx `proxies`、`test_integration.py` 里已下线的 `gpt3` 别名、缺 `reportlab`）。基线的第 4 个失败 `test_google_translate_epub` 是网络波动，本次通过。
- 真实端点 `gpt-5.6-luna`：探测判定为 `strict`，单段与批量 `.parse` 均返回正确的繁体中文。
- 真实端点 `gpt-5.6-luna` + `temperature=0.1`：实际报错为 `Unsupported value: 'temperature' does not support 0.1 with this model`，被判定为 `temperature`，去掉该参数重试后翻译成功，结构化输出的支持状态未被误改。

- 真实端点 `gpt-5.6-luna`，把探测强制改为抛 `APIConnectionError`：不抛异常、不缓存结论、本次走分隔符模式；恢复真实 client 后下一次调用判定为 `strict` 并正确翻译。

Structured Outputs 参考：https://developers.openai.com/api/docs/guides/structured-outputs

### 7. 保留原有的容错行为

本项目的前提是「一本书要在几个小时里翻完，期间网关会抽风然后恢复」。原本的容错机制——`get_translation` 上的 tenacity（3 次，指数退避 2→60s）、`_do_structured_batch_translate` 里退回逐段翻译的宽 `except`、`epub_loader.py` 顶层保存进度和临时书后退出以便 `--resume`——全部保持不动。

上面几项改动的第一版削弱了它，已经修回：

| 之前 | 现在 |
|---|---|
| 探测把 `RateLimitError`／`APIConnectionError`／`APITimeoutError` 直接抛出。而 `translate_list` 里的探测**不在**任何 tenacity 包裹内，于是整个任务的第一次 API 调用碰上限流就会零重试终止。 | 改为推迟：不记录结论，本次调用走分隔符模式，下一段重新探测。紧随其后的真实请求会碰到同一次故障，并拿到 tenacity 的重试——瞬时故障本来就该在那里处理。 |
| `LengthFinishReasonError` 从单段路径抛出，重试 3 次同样的内容后任务结束。 | 在 `get_translation` 里捕获，改用 `_plain_translation` 重译该段。残缺 JSON 依然不会进书里（这才是抛错的目的），但也不会因为一个长段落废掉整次运行。批量路径原本就被宽 `except` 兜住了。 |
| 代理返回一次乱码导致的 `ValidationError` 就把该模型的结构化输出永久关掉。 | 需要连续 2 次能力失败才降级，任意一次成功的结构化调用会清零计数。 |

仍然明确报错的情况：模型拒答、批量结果被截断、以及 `_classify_bad_request` 无法归因到 temperature 或 schema 的 400。

对应错误分类也从两类拆成三类：`PROBE_FATAL_ERRORS`（`AuthenticationError`、`PermissionDeniedError`、`NotFoundError`，端点层面的永久性答复，向上抛）、`PROBE_TRANSIENT_ERRORS`（推迟探测）、其余（降级并打印）。
