### PR TITLE
fix(openai): 将目标语言写入结构化输出 schema

### DIFF
--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -116,14 +116,14 @@ def batch_translation_model(language):
 
 def _single_field_description(language):
     target = language or "the target language"
-    return f"The source text translated into {target}. Write {target} only."
+    return f"The source text translated into {target}."
 
 
 def _batch_field_description(language):
     target = language or "the target language"
     return (
         f"The source paragraphs translated into {target}, one per input "
-        f"paragraph and in the same order. Write {target} only."
+        f"paragraph and in the same order."
     )
 
 

--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -77,17 +77,15 @@ def batch_field_name(language):
     return f"{slug}_paragraphs" if slug else "paragraphs"
 
 
-def _schema_suffix(language):
-    slug = _language_slug(language)
-    return f"_{slug}" if slug else ""
-
-
+# The schema name is sent to the model, which never has to tell the single
+# schema from the batch one -- a request carries exactly one. So name each
+# schema after the field it wraps rather than after our own call sites.
 @lru_cache(maxsize=None)
 def single_translation_model(language):
     """Structured single translation output, pinned to `language`."""
     field = single_field_name(language)
     return create_model(
-        f"SingleTranslation{_schema_suffix(language)}",
+        field,
         __config__=ConfigDict(extra="forbid"),
         **{
             field: (
@@ -103,7 +101,7 @@ def batch_translation_model(language):
     """Structured batch translation output, pinned to `language`."""
     field = batch_field_name(language)
     return create_model(
-        f"BatchTranslation{_schema_suffix(language)}",
+        field,
         __config__=ConfigDict(extra="forbid"),
         **{
             field: (
@@ -136,7 +134,7 @@ def single_translation_schema(language):
     """
     field = single_field_name(language)
     return {
-        "name": f"single_translation{_schema_suffix(language)}",
+        "name": field,
         "strict": True,
         "schema": {
             "type": "object",

--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -232,6 +232,7 @@ GPT4o_MODEL_LIST = [
 ]
 GPT5MINI_MODEL_LIST = [
     "gpt-5-mini",
+    "gpt-5.4-mini",
 ]
 O1PREVIEW_MODEL_LIST = [
     "o1-preview",

--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -5,6 +5,7 @@ import shutil
 from os import environ
 from itertools import cycle
 import json
+from functools import lru_cache
 from threading import Lock, RLock
 
 from openai import (
@@ -19,7 +20,7 @@ from openai import (
     PermissionDeniedError,
     RateLimitError,
 )
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import ConfigDict, Field, ValidationError, create_model
 from rich import print
 from tenacity import (
     retry,
@@ -48,38 +49,115 @@ class StructuredOutputUnsupported(Exception):
     """
 
 
-class BatchTranslation(BaseModel):
-    """Structured batch translation output (OpenAI Structured Outputs)."""
+# The schema is the last thing the model reads before it decodes, and a bare
+# `translated`/`paragraphs` field says nothing about *which* language to produce
+# — the target language would otherwise live only in the middle of the prompt.
+# So the language is baked into the field name, its description and the schema
+# name: `simplified chinese` -> `simplified_chinese_translation`. Separator is
+# `_` rather than `-`; hyphens are legal JSON keys, but this file exists because
+# OpenAI-compatible proxies mishandle things, and `_` is the conservative shape.
+def _language_slug(language):
+    """Field-name token for `language`, or "" when there is nothing usable."""
+    return re.sub(r"[^a-z0-9]+", "_", (language or "").strip().lower()).strip("_")
 
-    model_config = ConfigDict(extra="forbid")
 
-    paragraphs: list[str]
+def single_field_name(language):
+    """Name of the single-translation field for `language`.
+
+    Shared by the SDK path and the hand-built Batch API schema so the two cannot
+    drift; the Batch API reader keys off this too.
+    """
+    slug = _language_slug(language)
+    return f"{slug}_translation" if slug else "translated"
 
 
-class SingleTranslation(BaseModel):
-    """Structured single translation output."""
+def batch_field_name(language):
+    """Name of the batch-translation field for `language`."""
+    slug = _language_slug(language)
+    return f"{slug}_paragraphs" if slug else "paragraphs"
 
-    model_config = ConfigDict(extra="forbid")
 
-    translated: str
+def _schema_suffix(language):
+    slug = _language_slug(language)
+    return f"_{slug}" if slug else ""
+
+
+@lru_cache(maxsize=None)
+def single_translation_model(language):
+    """Structured single translation output, pinned to `language`."""
+    field = single_field_name(language)
+    return create_model(
+        f"SingleTranslation{_schema_suffix(language)}",
+        __config__=ConfigDict(extra="forbid"),
+        **{
+            field: (
+                str,
+                Field(description=_single_field_description(language)),
+            )
+        },
+    )
+
+
+@lru_cache(maxsize=None)
+def batch_translation_model(language):
+    """Structured batch translation output, pinned to `language`."""
+    field = batch_field_name(language)
+    return create_model(
+        f"BatchTranslation{_schema_suffix(language)}",
+        __config__=ConfigDict(extra="forbid"),
+        **{
+            field: (
+                list[str],
+                Field(description=_batch_field_description(language)),
+            )
+        },
+    )
+
+
+def _single_field_description(language):
+    target = language or "the target language"
+    return f"The source text translated into {target}. Write {target} only."
+
+
+def _batch_field_description(language):
+    target = language or "the target language"
+    return (
+        f"The source paragraphs translated into {target}, one per input "
+        f"paragraph and in the same order. Write {target} only."
+    )
+
+
+@lru_cache(maxsize=None)
+def single_translation_schema(language):
+    """Mirror of `single_translation_model` for the Batch API.
+
+    Batch JSONL bodies are built by hand and so cannot use the SDK's Pydantic
+    support; both sides take their field name from `single_field_name`.
+    """
+    field = single_field_name(language)
+    return {
+        "name": f"single_translation{_schema_suffix(language)}",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                field: {
+                    "type": "string",
+                    "description": _single_field_description(language),
+                }
+            },
+            "required": [field],
+            "additionalProperties": False,
+        },
+    }
 
 
 # Capability probe. The prompt asks for plain text and the schema pins a
 # single-value enum, so the only way `PROBE_EXPECTED` can come back is if the
 # server actually applied the schema to decoding. A proxy that accepts
 # `response_format` and quietly drops it answers with the prompted text instead.
-# Mirror of SingleTranslation for the Batch API, whose JSONL bodies are built by
-# hand and therefore cannot use the SDK's Pydantic support.
-SINGLE_TRANSLATION_SCHEMA = {
-    "name": "single_translation",
-    "strict": True,
-    "schema": {
-        "type": "object",
-        "properties": {"translated": {"type": "string"}},
-        "required": ["translated"],
-        "additionalProperties": False,
-    },
-}
+# Deliberately language-free: this asks whether the endpoint honors schemas at
+# all, and a translation-shaped probe would confuse that with a bad translation.
 
 # The API's own default. Sending it explicitly changes nothing for models that
 # accept it, and is a hard 400 for models that only allow their default.
@@ -491,13 +569,14 @@ class ChatGPTAPI(Base):
         (never returns the truncated JSON fragment), and `ValueError` on refusal.
         """
         messages = self.create_messages(text, self.create_context_messages())
+        field = single_field_name(self.language)
 
         try:
             completion = self._request(
                 lambda sampling: self.openai_client.chat.completions.parse(
                     model=self.model,
                     messages=messages,
-                    response_format=SingleTranslation,
+                    response_format=single_translation_model(self.language),
                     extra_body=self.extra_body if self.extra_body else None,
                     **sampling,
                 )
@@ -517,7 +596,7 @@ class ChatGPTAPI(Base):
             raise StructuredOutputUnsupported("no parsed content in response")
 
         self._note_structured_success()
-        return message.parsed.translated
+        return getattr(message.parsed, field)
 
     def _plain_translation(self, text):
         completion = self.create_chat_completion(text)
@@ -679,10 +758,15 @@ class ChatGPTAPI(Base):
             text=texts_json, language=self.language, crlf="\n"
         )
 
-        # Add structured format instruction
+        # Add structured format instruction. The target language goes last: this
+        # is the final thing the model reads before decoding, and a shape-only
+        # tail leaves `{language}` buried behind the source JSON blob above.
+        field = batch_field_name(self.language)
         content = (
             f"{user_prompt}\n\n"
-            f"Return a JSON object with a 'paragraphs' array containing EXACTLY {plist_len} translated strings."
+            f"Return a JSON object whose '{field}' array contains EXACTLY "
+            f"{plist_len} strings, one per input paragraph and in the same "
+            f"order, each written in {self.language}."
         )
 
         sys_content = self.system_content or self.prompt_sys_msg.format(crlf="\n")
@@ -739,7 +823,7 @@ class ChatGPTAPI(Base):
                 lambda sampling: self.openai_client.chat.completions.parse(
                     model=self.model,
                     messages=messages,
-                    response_format=BatchTranslation,
+                    response_format=batch_translation_model(self.language),
                     extra_body=self.extra_body if self.extra_body else None,
                     **sampling,
                 )
@@ -757,7 +841,7 @@ class ChatGPTAPI(Base):
         if message.parsed is None:
             raise StructuredOutputUnsupported("no parsed content in response")
 
-        paragraphs = message.parsed.paragraphs
+        paragraphs = getattr(message.parsed, batch_field_name(self.language))
 
         # A wrong count is a model error, not a capability answer: retry it.
         if len(paragraphs) != plist_len:
@@ -1105,18 +1189,22 @@ class ChatGPTAPI(Base):
                 result = json.loads(line)
                 if result["custom_id"] == custom_id:
                     return self._read_batch_choice(
-                        result["response"]["body"]["choices"][0], custom_id
+                        result["response"]["body"]["choices"][0],
+                        custom_id,
+                        self.language,
                     )
 
         raise ValueError(f"No result found for custom_id {custom_id}")
 
     @staticmethod
-    def _read_batch_choice(choice, custom_id):
+    def _read_batch_choice(choice, custom_id, language):
         """Unwrap one Batch API choice.
 
         Results are often fetched by a later process that never probed the
         model, so this decides from the payload itself rather than from cached
         capability state — and refuses to hand back a truncated JSON fragment.
+        `language` only names the field to look for; nothing here inspects the
+        text itself.
         """
         message = choice.get("message", {})
         if message.get("refusal"):
@@ -1134,9 +1222,21 @@ class ChatGPTAPI(Base):
         except json.JSONDecodeError:
             return content  # delimiter-mode batch, plain text is expected
 
-        if isinstance(parsed, dict) and isinstance(parsed.get("translated"), str):
-            return parsed["translated"]
-        return content
+        if not isinstance(parsed, dict):
+            return content  # delimiter-mode batch, plain text is expected
+
+        # A structured answer whose key we cannot find is not text: returning
+        # `content` would paste the raw JSON into the book. The usual cause is a
+        # result file produced under a different --language than this run.
+        field = single_field_name(language)
+        value = parsed.get(field)
+        if not isinstance(value, str):
+            raise ValueError(
+                f"Batch result for {custom_id} has no '{field}' string; "
+                f"got keys {sorted(parsed)}. A result file from a run with a "
+                f"different --language cannot be resumed under this one."
+            )
+        return value
 
     def create_batch_context_messages(self, index):
         messages = []
@@ -1181,11 +1281,11 @@ class ChatGPTAPI(Base):
         }
 
         # The Batch API takes hand-built bodies, so the schema cannot come from
-        # the SDK here; SINGLE_TRANSLATION_SCHEMA mirrors SingleTranslation.
+        # the SDK here; single_translation_schema mirrors the Pydantic model.
         if self._ensure_structured_support(self.batch_model):
             batch_body["response_format"] = {
                 "type": "json_schema",
-                "json_schema": SINGLE_TRANSLATION_SCHEMA,
+                "json_schema": single_translation_schema(self.language),
             }
 
         return {

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -732,6 +732,11 @@ def test_hand_built_batch_schema_matches_the_sdk_model():
         field = single_field_name(language)
 
         assert schema["strict"] is True
+        # The SDK sends the model's class name as the schema name, so both
+        # transports must land on the same one.
+        assert schema["name"] == field
+        assert single_translation_model(language).__name__ == field
+        assert batch_translation_model(language).__name__ == batch_field_name(language)
         assert schema["schema"]["required"] == [field]
         assert schema["schema"]["additionalProperties"] is False
         assert list(schema["schema"]["properties"]) == [field]

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -20,8 +20,29 @@ from openai import (
 from book_maker.translator.chatgptapi_translator import (
     ChatGPTAPI,
     StructuredOutputUnsupported,
+    batch_field_name,
+    batch_translation_model,
+    single_field_name,
+    single_translation_model,
+    single_translation_schema,
 )
 from book_maker.translator.groq_translator import GroqClient
+
+# Every translator built by `_translator` uses this language, so the structured
+# fields are named after it.
+LANGUAGE = "Chinese"
+SINGLE_FIELD = single_field_name(LANGUAGE)
+BATCH_FIELD = batch_field_name(LANGUAGE)
+
+
+def _single(text):
+    """`.parsed` for a single translation in the fixture's language."""
+    return SimpleNamespace(**{SINGLE_FIELD: text})
+
+
+def _batch(paragraphs):
+    """`.parsed` for a batch translation in the fixture's language."""
+    return SimpleNamespace(**{BATCH_FIELD: paragraphs})
 
 
 def _completion(content, finish_reason="stop"):
@@ -298,14 +319,14 @@ def test_concurrent_workers_probe_a_model_only_once():
 
 
 def test_single_translation_returns_parsed_field():
-    parse = Mock(
-        return_value=_parsed_completion(parsed=SimpleNamespace(translated="你好"))
-    )
+    parse = Mock(return_value=_parsed_completion(parsed=_single("你好")))
     translator = _translator(parse=parse)
     translator._structured_support["test-model"] = True
 
     assert translator.get_translation("hello") == "你好"
-    assert parse.call_args.kwargs["response_format"].__name__ == "SingleTranslation"
+    assert parse.call_args.kwargs["response_format"] is single_translation_model(
+        LANGUAGE
+    )
 
 
 def test_truncated_response_raises_instead_of_leaking_json_fragment():
@@ -388,7 +409,7 @@ def test_a_working_structured_call_clears_the_failure_streak():
     parse = Mock(
         side_effect=[
             StructuredOutputUnsupported("blip"),
-            _parsed_completion(parsed=SimpleNamespace(translated="你好")),
+            _parsed_completion(parsed=_single("你好")),
             StructuredOutputUnsupported("blip"),
         ]
     )
@@ -416,9 +437,7 @@ def test_batch_path_demotes_without_burning_retries():
 
 
 def test_batch_length_mismatch_is_retried_then_falls_back_one_by_one():
-    parse = Mock(
-        return_value=_parsed_completion(parsed=SimpleNamespace(paragraphs=["only one"]))
-    )
+    parse = Mock(return_value=_parsed_completion(parsed=_batch(["only one"])))
     translator = _translator(parse=parse)
     translator._structured_support["test-model"] = True
     translator.translate = Mock(side_effect=lambda text, _=True: f"t:{text}")
@@ -432,15 +451,13 @@ def test_batch_length_mismatch_is_retried_then_falls_back_one_by_one():
 
 
 def test_batch_success_returns_paragraphs():
-    parse = Mock(
-        return_value=_parsed_completion(parsed=SimpleNamespace(paragraphs=["一", "二"]))
-    )
+    parse = Mock(return_value=_parsed_completion(parsed=_batch(["一", "二"])))
     translator = _translator(parse=parse)
     translator._structured_support["test-model"] = True
 
     assert translator._do_structured_batch_translate(["a", "b"]) == ["一", "二"]
     request = parse.call_args.kwargs
-    assert request["response_format"].__name__ == "BatchTranslation"
+    assert request["response_format"] is batch_translation_model(LANGUAGE)
     assert json.loads  # payload is built by the SDK, not hand-rolled
 
 
@@ -469,9 +486,7 @@ def test_groq_never_probes_for_structured_outputs():
 def test_default_temperature_is_not_sent():
     """1.0 is the API default, so sending it is a no-op — except on models that
     reject any explicit temperature."""
-    parse = Mock(
-        return_value=_parsed_completion(parsed=SimpleNamespace(translated="你好"))
-    )
+    parse = Mock(return_value=_parsed_completion(parsed=_single("你好")))
     translator = _translator(parse=parse)
     translator.temperature = 1.0
     translator._structured_support["test-model"] = True
@@ -482,9 +497,7 @@ def test_default_temperature_is_not_sent():
 
 
 def test_explicit_temperature_is_sent():
-    parse = Mock(
-        return_value=_parsed_completion(parsed=SimpleNamespace(translated="你好"))
-    )
+    parse = Mock(return_value=_parsed_completion(parsed=_single("你好")))
     translator = _translator(parse=parse)
     translator.temperature = 0.1
     translator._structured_support["test-model"] = True
@@ -505,7 +518,7 @@ def test_plain_path_also_honors_the_default_temperature_rule():
 
 
 def test_temperature_rejection_retries_once_without_it_and_is_cached():
-    ok = _parsed_completion(parsed=SimpleNamespace(translated="你好"))
+    ok = _parsed_completion(parsed=_single("你好"))
     parse = Mock(
         side_effect=[
             _api_error(
@@ -533,7 +546,7 @@ def test_temperature_rejection_retries_once_without_it_and_is_cached():
 
 
 def test_temperature_rejection_does_not_demote_structured_outputs():
-    ok = _parsed_completion(parsed=SimpleNamespace(translated="你好"))
+    ok = _parsed_completion(parsed=_single("你好"))
     parse = Mock(
         side_effect=[
             _api_error(BadRequestError, 400, "temperature is not supported"),
@@ -577,9 +590,7 @@ def test_unrelated_bad_request_is_not_blamed_on_the_schema():
 
 
 def test_batch_path_applies_the_same_temperature_rule():
-    parse = Mock(
-        return_value=_parsed_completion(parsed=SimpleNamespace(paragraphs=["一", "二"]))
-    )
+    parse = Mock(return_value=_parsed_completion(parsed=_batch(["一", "二"])))
     translator = _translator(parse=parse)
     translator.temperature = 1.0
     translator._structured_support["test-model"] = True
@@ -620,16 +631,16 @@ def test_batch_api_body_omits_default_temperature():
 def test_batch_choice_unwraps_structured_content_without_cached_state():
     choice = {
         "finish_reason": "stop",
-        "message": {"content": '{"translated":"你好"}'},
+        "message": {"content": json.dumps({SINGLE_FIELD: "你好"})},
     }
 
-    assert ChatGPTAPI._read_batch_choice(choice, "id-1") == "你好"
+    assert ChatGPTAPI._read_batch_choice(choice, "id-1", LANGUAGE) == "你好"
 
 
 def test_batch_choice_passes_through_plain_content():
     choice = {"finish_reason": "stop", "message": {"content": "plain text"}}
 
-    assert ChatGPTAPI._read_batch_choice(choice, "id-1") == "plain text"
+    assert ChatGPTAPI._read_batch_choice(choice, "id-1", LANGUAGE) == "plain text"
 
 
 def test_batch_choice_rejects_truncated_result():
@@ -639,14 +650,121 @@ def test_batch_choice_rejects_truncated_result():
     }
 
     with pytest.raises(ValueError, match="truncated"):
-        ChatGPTAPI._read_batch_choice(choice, "id-1")
+        ChatGPTAPI._read_batch_choice(choice, "id-1", LANGUAGE)
 
 
 def test_batch_choice_rejects_refusal():
     choice = {"finish_reason": "stop", "message": {"refusal": "nope", "content": None}}
 
     with pytest.raises(ValueError, match="refused"):
-        ChatGPTAPI._read_batch_choice(choice, "id-1")
+        ChatGPTAPI._read_batch_choice(choice, "id-1", LANGUAGE)
+
+
+def test_batch_choice_rejects_structured_object_from_another_language():
+    """A result file written under a different --language must not be pasted
+    into the book as raw JSON."""
+    choice = {
+        "finish_reason": "stop",
+        "message": {"content": json.dumps({"german_translation": "hallo"})},
+    }
+
+    with pytest.raises(ValueError, match=SINGLE_FIELD):
+        ChatGPTAPI._read_batch_choice(choice, "id-1", LANGUAGE)
+
+
+# --------------------------------------------------------------------------
+# The schema itself carries the target language: field name, description and
+# schema name. Without it the last thing the model reads before decoding says
+# only what shape to emit, never which language.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("language", "single", "batch"),
+    [
+        ("Chinese", "chinese_translation", "chinese_paragraphs"),
+        (
+            "simplified chinese",
+            "simplified_chinese_translation",
+            "simplified_chinese_paragraphs",
+        ),
+        (
+            "Simplified Chinese",
+            "simplified_chinese_translation",
+            "simplified_chinese_paragraphs",
+        ),
+        # cli.py maps codes through LANGUAGES, but a raw code must still slug.
+        ("zh-hans", "zh_hans_translation", "zh_hans_paragraphs"),
+        ("", "translated", "paragraphs"),  # nothing usable: language-free names
+        (None, "translated", "paragraphs"),
+    ],
+)
+def test_field_names_follow_the_target_language(language, single, batch):
+    assert single_field_name(language) == single
+    assert batch_field_name(language) == batch
+
+
+def test_models_expose_the_language_named_field_and_say_so():
+    model = single_translation_model("simplified chinese")
+    schema = model.model_json_schema()
+    field = schema["properties"]["simplified_chinese_translation"]
+
+    assert schema["required"] == ["simplified_chinese_translation"]
+    assert "simplified chinese" in field["description"]
+    assert model.model_config["extra"] == "forbid"
+
+    batch = batch_translation_model("simplified chinese").model_json_schema()
+    assert "simplified chinese" in (
+        batch["properties"]["simplified_chinese_paragraphs"]["description"]
+    )
+
+
+def test_models_are_cached_per_language():
+    """One `create_model` per language, not one per paragraph."""
+    assert single_translation_model("Chinese") is single_translation_model("Chinese")
+    assert single_translation_model("Chinese") is not single_translation_model("German")
+
+
+def test_hand_built_batch_schema_matches_the_sdk_model():
+    """The Batch API body is hand-rolled; it must not drift from the model."""
+    for language in ("Chinese", "simplified chinese", ""):
+        schema = single_translation_schema(language)
+        field = single_field_name(language)
+
+        assert schema["strict"] is True
+        assert schema["schema"]["required"] == [field]
+        assert schema["schema"]["additionalProperties"] is False
+        assert list(schema["schema"]["properties"]) == [field]
+        assert (
+            schema["schema"]["properties"][field]["description"]
+            == single_translation_model(language).model_json_schema()["properties"][
+                field
+            ]["description"]
+        )
+
+
+def test_batch_request_pins_the_language_schema():
+    translator = _translator()
+    translator.batch_model = "test-model"
+    translator.custom_id = lambda index: f"id-{index}"
+    translator.context_flag = False
+    translator._structured_support["test-model"] = True
+
+    body = translator.make_batch_request(0, "hello")["body"]
+
+    assert body["response_format"]["json_schema"] == single_translation_schema(LANGUAGE)
+
+
+def test_structured_batch_prompt_ends_on_the_target_language():
+    """Recency matters: a shape-only tail leaves `{language}` buried behind the
+    source JSON blob."""
+    translator = _translator()
+
+    content = translator._create_structured_batch_messages(["a", "b"])[-1]["content"]
+
+    assert content.rstrip().endswith(f"each written in {LANGUAGE}.")
+    assert f"'{BATCH_FIELD}'" in content
+    assert "EXACTLY 2" in content
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

结构化输出（Structured Outputs）只约束了返回的**结构**，从未约束**语言**。

`SingleTranslation.translated` 和 `BatchTranslation.paragraphs` 是静态定义、没有 description 的字段，因此目标语言唯一出现的地方，是用户 prompt 中间被插值进去的 `{language}`。

批量路径的情况更糟。原先追加的指令只讲结构：

```
Return a JSON object with a 'paragraphs' array containing EXACTLY N translated strings.
```

也就是说，模型在解码前读到的**最后一句话**完全没有提到语言，而 `{language}` 被压在一大段 `json.dumps(text_list)` 的原文后面——批量越大，埋得越深。

同时没有任何地方会发现语言错了：批量路径只校验数量，单段路径在 parse 之后不做校验。

## 改动

字段名、字段描述、schema 名称都由 `self.language` 推导：

| 辅助函数 | `"simplified chinese"` 的结果 |
| --- | --- |
| `single_field_name(language)` | `simplified_chinese_translation` |
| `batch_field_name(language)` | `simplified_chinese_paragraphs` |
| `single_translation_model(language)` | 模型名 / schema 名同为 `simplified_chinese_translation` |
| `batch_translation_model(language)` | 模型名 / schema 名同为 `simplified_chinese_paragraphs` |

字段描述形如 *"The source text translated into simplified chinese."*，这样解码器看到的约束本身就带着语言，而不只是结构。描述里刻意不写 "Write X only."——用户自定义 prompt 有时会要求专有名词或人名保持原文，那句话会与之冲突。

其他改动：

- 批量指令改为**以语言结尾**：`...EXACTLY N strings, one per input paragraph and in the same order, each written in {language}.`
- schema 名称直接取字段名。schema 名是会发给模型的，而模型并不需要把单段 schema 和批量 schema 区分开——一次请求里只有一个 `response_format`。原先的 `single_translation_x` / `SingleTranslation_x` 只是把调用侧自己的词汇泄漏进了 prompt。SDK 会把 pydantic 类的 `__name__` 当作 `json_schema.name` 发出去，因此两条链路（SDK 与手写的 Batch API body）取同一个名字，包装名也就复述了模型必须输出的那个 key。
- 模型用 `pydantic.create_model` 配合 `lru_cache` 构造，因此是「每种语言一个模型」，而不是「每段一个模型」。
- `language` 为空时回退到原来的 `translated` / `paragraphs`，行为不变。
- 分隔符用 `_` 而非 `-`。连字符在 `to_strict_json_schema` 和 pydantic 往返中验证可用（openai 2.44.0），但这个文件本身就是为了应对各种 OpenAI 兼容代理的怪异行为而存在的，所以选了更保守的写法。
- `_read_batch_choice` 现在显式接收 `language`（它是 `@staticmethod`，因为读取结果的进程往往没有做过探测）。它原先在 JSON 对象里找不到 `translated` 时会 `return content`，等于把原始 JSON 贴进书里；现在改为抛错。字段名与语言绑定后，这种不匹配的概率大幅上升——用另一个 `--language` 产生的批量结果文件无法在本次运行中续跑。
- 能力探测（probe）刻意保持与语言无关：它要回答的是「这个 endpoint 到底认不认 schema」，如果探测本身长得像一次翻译，就会把「不支持 schema」和「翻译得不好」混为一谈。

## 不在本次范围内

**检测**返回文本是否真的是目标语言。现在 schema 会「要求」正确的语言，但没有任何地方去验证。

## 测试

`tests/test_chatgptapi_translator.py` 共 60 项通过。新增覆盖：

- 各种大小写与语言代码下的 slug 推导（`Chinese` / `simplified chinese` / `Simplified Chinese` / `zh-hans` / 空值）
- 字段描述中确实带有目标语言
- 每种语言的模型只构造一次（缓存）
- 手写的 Batch API schema 与 SDK 模型逐字段一致——两者是手工镜像的，必须防止漂移
- `make_batch_request` 使用对应语言的 schema
- 批量 prompt 以目标语言结尾
- 来自其他语言的结果文件会被明确拒绝，而不是静默地把 JSON 写进书里

## 另附一个 commit

`feat(openai): add gpt-5.4-mini to the gpt5mini model family` —— 与上面的改动无关，如果不合适可以只取第一个 commit。`--model gpt5mini` 会把 `GPT5MINI_MODEL_LIST` 与当前 key 实际可见的模型取交集，所以列一个账号没有权限的模型不会有副作用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxyAJz6mcwKQHb7j1BCXEr


