### PR TITLE
fix(md): --use_context 并行分节按 worker 份额划分，单一 H1 / 无标题文档也能并行

### DIFF
--- a/book_maker/loader/md_loader.py
+++ b/book_maker/loader/md_loader.py
@@ -405,36 +405,97 @@ class MarkdownBookLoader(BaseBookLoader):
             f"Markdown parallel context: {len(sections)} sections "
             f"across {effective_workers} workers."
         )
+        # Largest-first submission so the longest sequential chain starts
+        # immediately (minimizes makespan); results are index-addressed, so
+        # submission order never affects output order.
+        ordered = sorted(sections, key=self._section_chars, reverse=True)
         with ThreadPoolExecutor(max_workers=effective_workers) as executor:
             futures = [
                 executor.submit(self._translate_section, section, results, report)
-                for section in sections
+                for section in ordered
             ]
             for future in as_completed(futures):
                 future.result()
 
     def _group_sections(self, pending):
-        """Split pending (index, batch) items into contiguous sections keyed by
-        their top-level heading, so each section is an independent context unit.
+        """Partition pending (index, batch) items into contiguous sections
+        that balance worker occupancy against context coherence.
+
+        Batches are first grouped into the finest heading-delimited units
+        (full breadcrumb). Heading units are atomic: context accumulates in
+        reading order inside them and never splits below a heading.
+        Breadcrumb-less runs (documents without headings) larger than one
+        worker share are windowed by char budget so they parallelize too.
+        Contiguous units are then coalesced greedily up to one worker share
+        (total chars / workers): small neighbors run sequentially on one
+        translator clone with context carried across them, while big units
+        keep a worker to themselves.
         """
-        sections = []
+        units = []
         current = []
         current_key = None
         for index, batch in pending:
-            key = self._section_key(batch)
+            key = batch.breadcrumb or ""
             if current and key != current_key:
-                sections.append(current)
+                units.append((current_key, current))
                 current = []
             current.append((index, batch))
             current_key = key
         if current:
-            sections.append(current)
+            units.append((current_key, current))
+
+        total_chars = sum(self._section_chars(unit) for _, unit in units)
+        share = max(1, total_chars // max(1, self.parallel_workers))
+
+        windowed = []
+        for key, unit in units:
+            if key == "" and self._section_chars(unit) > share:
+                windowed.extend(self._window_entries(unit, share))
+            else:
+                windowed.append(unit)
+
+        sections = []
+        section = []
+        section_chars = 0
+        for unit in windowed:
+            unit_chars = self._section_chars(unit)
+            if section and section_chars + unit_chars > share:
+                sections.append(section)
+                section = []
+                section_chars = 0
+            section.extend(unit)
+            section_chars += unit_chars
+        if section:
+            sections.append(section)
         return sections
 
+    @classmethod
+    def _section_chars(cls, entries):
+        return sum(cls._entry_chars(entry) for entry in entries)
+
     @staticmethod
-    def _section_key(batch):
-        breadcrumb = batch.breadcrumb or ""
-        return breadcrumb.split(" > ")[0].strip()
+    def _entry_chars(entry):
+        _, batch = entry
+        return sum(len(text) for text in batch.block_texts)
+
+    @classmethod
+    def _window_entries(cls, entries, share):
+        """Chunk a contiguous run of (index, batch) entries into windows of
+        roughly one worker share each; every window keeps at least one entry."""
+        windows = []
+        window = []
+        window_chars = 0
+        for entry in entries:
+            entry_chars = cls._entry_chars(entry)
+            if window and window_chars + entry_chars > share:
+                windows.append(window)
+                window = []
+                window_chars = 0
+            window.append(entry)
+            window_chars += entry_chars
+        if window:
+            windows.append(window)
+        return windows
 
     def _translate_section(self, section, results, report):
         """Translate one section's batches in reading order on an isolated

--- a/tests/test_md_loader.py
+++ b/tests/test_md_loader.py
@@ -499,6 +499,101 @@ def test_markdown_use_context_isolates_context_per_section(tmp_path):
     assert ctx_values == [0, 0, 1, 1, 2, 2]
 
 
+def test_markdown_context_single_h1_book_still_runs_parallel(tmp_path):
+    # A book with one H1 used to collapse into a single section, so
+    # --use_context ran fully sequential no matter how many workers.
+    book = tmp_path / "book.md"
+    book.write_text("# Book\n\n## One\n\nFirst body.\n\n## Two\n\nSecond body.\n")
+
+    loader = make_loader(
+        book,
+        SlowListModel,
+        context_flag=True,
+        parallel_workers=4,
+    )
+    loader.batch_size = 1
+    loader.make_bilingual_book()
+
+    # The H2 subsections translate concurrently on isolated clones.
+    assert SlowListModel.cls_max_active > 1
+
+    content = (tmp_path / "book_bilingual.md").read_text(encoding="utf-8")
+    assert content.count("<T>") == 5
+    assert content.index("<T>First body.</T>") < content.index("<T>Second body.</T>")
+
+
+def test_markdown_context_isolation_holds_at_finest_heading_units(tmp_path):
+    book = tmp_path / "book.md"
+    book.write_text(
+        "# Book\n\n## One\n\nOne body a.\n\nOne body b.\n\n"
+        "## Two\n\nTwo body a.\n\nTwo body b.\n"
+    )
+
+    loader = make_loader(
+        book,
+        AccumulatingContextModel,
+        context_flag=True,
+        parallel_workers=4,
+    )
+    loader.batch_size = 1
+    loader.make_bilingual_book()
+
+    content = (tmp_path / "book_bilingual.md").read_text(encoding="utf-8")
+    ctx_values = sorted(int(m) for m in re.findall(r"<T ctx=(\d+)>", content))
+    # Sections: [# Book] and one per H2 (heading, body a, body b -> ctx
+    # 0,1,2). Without per-subsection isolation the later batches would
+    # continue at 3,4,5.
+    assert ctx_values == [0, 0, 0, 1, 1, 2, 2]
+
+
+def test_markdown_context_sections_coalesce_to_worker_share(tmp_path):
+    book = tmp_path / "book.md"
+    book.write_text(
+        "# One\n\n## One A\n\nBody 1a.\n\n## One B\n\nBody 1b.\n\n"
+        "# Two\n\n## Two A\n\nBody 2a.\n\n## Two B\n\nBody 2b.\n"
+    )
+
+    loader = make_loader(
+        book,
+        ListModel,
+        context_flag=True,
+        parallel_workers=2,
+    )
+    loader.batch_size = 1
+    _, batches = loader._enumerate_render_items()
+    pending = list(enumerate(batches))
+
+    # Two workers, two same-size H1 halves: small heading units coalesce
+    # back to one section per worker share instead of one per H2.
+    sections = loader._group_sections(pending)
+    assert len(sections) == 2
+    # Sections stay contiguous and cover every batch exactly once.
+    flat = [index for section in sections for index, _ in section]
+    assert flat == list(range(len(batches)))
+
+
+def test_markdown_context_headingless_book_windows_and_runs_parallel(tmp_path):
+    book = tmp_path / "book.md"
+    book.write_text("One body.\n\nTwo body.\n\nThree body.\n\nFour body.\n")
+
+    loader = make_loader(
+        book,
+        SlowListModel,
+        context_flag=True,
+        parallel_workers=2,
+    )
+    loader.batch_size = 1
+    loader.make_bilingual_book()
+
+    # No headings at all: the single breadcrumb-less run is windowed by
+    # char share so workers are still occupied.
+    assert SlowListModel.cls_max_active > 1
+
+    content = (tmp_path / "book_bilingual.md").read_text(encoding="utf-8")
+    assert content.count("<T>") == 4
+    assert content.index("<T>One body.</T>") < content.index("<T>Four body.</T>")
+
+
 def test_markdown_context_section_interrupt_persists_partial_section(tmp_path):
     book = tmp_path / "book.md"
     book.write_text("# One\n\nOne a.\n\nTwo.\n\nThree.\n")


### PR DESCRIPTION
## 问题

Markdown 的 `--use_context` 并行路径按**顶级标题**分节（`_section_key` 取 `breadcrumb.split(" > ")[0]`），每节一个 worker。

只有一个 `#` 的书（很常见：书名作为唯一 H1，正文全在 `##`/`###` 下）会坍缩成一个 section，`effective_workers = min(N, 1) = 1`——无论 `--parallel-workers` 设多少，整本书都在串行翻译，而且没有任何提示。完全没有标题的文档同样如此。

## 改动

把固定的 H1 切分换成按 worker 份额（`总字符数 / workers`）划分：

1. **最细标题单元**：先按完整 breadcrumb 把批次分成连续的最细单元（如每个 `### 小节`）。标题单元是原子的——单元内上下文严格按阅读顺序累积，永不从标题以下切开。
2. **无标题段落开窗**：没有 breadcrumb 的连续段落超过一个份额时按字符预算切窗，纯文本文档也能并行。
3. **贪心合并**：相邻小单元贪心合并到一个份额为止。合并后的 section 在同一个 translator clone 上顺序翻译，上下文跨单元连续累积；大单元独占一个 worker。
4. **最大优先提交**：最长的顺序链最先开跑，减小总时长。结果按批次下标写回，输出顺序不受提交顺序影响。

worker 数低时自动退化为更粗、上下文更连续的分节（份额变大 → section 变少变大）；`--parallel-workers 1` 完全不切分，行为与原先串行一致。断点续传 / 中断持久化 / 每节上下文隔离均不变。

## 实测

1039 批次的单一 H1 书（梨俱吠陀，13k 行）：

| workers | sections | 每节字符 |
| --- | --- | --- |
| 2 | 3 | ~641k |
| 4 | 5 | ~320k |
| 8 | 9 | ~160k |
| 30 | 31 | 29k–42k（份额 42.8k，均衡） |

修复前以上所有配置都是 1 个 section、串行。

## 测试

TDD，新增 4 个用例（先失败后通过）：单一 H1 书真正并行；最细单元的上下文隔离；两个等大 H1、2 workers 时合并回 2 个 section（不过度切分）；无标题文档开窗并行。`tests/test_md_loader.py` 18/18 通过，`ruff format` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)