### PR TITLE
fix(epub): stabilize parallel translation checkpoints

### DIFF
--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -4,8 +4,10 @@ import re
 import string
 import sys
 import time
+from dataclasses import dataclass, field
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import copy
+from hashlib import sha256
 from pathlib import Path
 import traceback
 from threading import Lock
@@ -23,7 +25,38 @@ from .base_loader import BaseBookLoader
 from .helper import EPUBBookLoaderHelper, is_text_link, not_trans, shorter_result_link
 
 
+@dataclass(frozen=True)
+class TranslationJob:
+    """A stable unit of EPUB translation work.
+
+    The positional fields are assigned before any translation starts, so API
+    completion order cannot change resume/cache identity. ``node`` deliberately
+    stays an implementation detail: persistence uses ``job_id`` and
+    ``global_index``, never a mutable BeautifulSoup object.
+    """
+
+    job_id: str
+    document_index: int
+    node_index: int
+    global_index: int
+    source_text: str
+    context_group: str
+    batch_index: int
+    node: object = field(repr=False, compare=False)
+
+
+@dataclass
+class ChapterTranslationPlan:
+    item: object
+    soup: object
+    jobs: list[TranslationJob]
+    include_in_output: bool = True
+
+
 class EPUBBookLoader(BaseBookLoader):
+    CHECKPOINT_VERSION = 3
+    CHECKPOINT_ORDER = "document"
+
     def __init__(
         self,
         epub_name,
@@ -79,7 +112,10 @@ class EPUBBookLoader(BaseBookLoader):
         self.parallel_workers = 1
         self.enable_parallel = False
         self._progress_lock = Lock()
-        self._translation_index = 0
+        self._pending_translation_results = {}
+        self._last_saved_progress = 0
+        self._checkpoint_job_ids = []
+        self._planned_job_ids = []
         self.set_parallel_workers(parallel_workers)
 
         # monkey patch for # 173
@@ -408,7 +444,7 @@ class EPUBBookLoader(BaseBookLoader):
                 cached = self.p_to_save[index]
                 entries.append((p, None, cached))
             else:
-                raw = p.text.rstrip()
+                raw = self._translation_source_text(p).rstrip()
                 entries.append((p, raw, None))
 
             index += 1
@@ -725,6 +761,123 @@ class EPUBBookLoader(BaseBookLoader):
         filtered_list = [p for p in p_list if not self.has_nest_child(p, trans_taglist)]
         return filtered_list
 
+    def _translation_source_text(self, node):
+        if isinstance(node, NavigableString):
+            return str(node)
+        extracted = self._extract_paragraph(copy(node))
+        return extracted.get_text()
+
+    @staticmethod
+    def _translation_job_id(document_index, file_name, node_index, source_text):
+        source_hash = sha256(source_text.encode("utf-8")).hexdigest()[:16]
+        return f"epub:{document_index}:{file_name}:{node_index}:{source_hash}"
+
+    def _assign_batch_indexes(self, source_texts):
+        if self.sentence_mode or (self.block_size < 1 and self.accumulated_num <= 1):
+            return list(range(len(source_texts)))
+
+        if self.accumulated_num > 1:
+            indexes = []
+            batch_index = 0
+            batch_tokens = 0
+            for source_text in source_texts:
+                token_count = num_tokens_from_text(source_text)
+                if batch_tokens and batch_tokens + token_count >= self.accumulated_num:
+                    batch_index += 1
+                    batch_tokens = 0
+                indexes.append(batch_index)
+                batch_tokens += token_count
+                if token_count > self.accumulated_num:
+                    batch_index += 1
+                    batch_tokens = 0
+            return indexes
+
+        return [index // self.block_size for index in range(len(source_texts))]
+
+    def _build_translation_plan(self, document_items, trans_taglist):
+        """Enumerate all EPUB work before requests begin.
+
+        Both execution modes consume these plans. File/tag filtering, test
+        limits, document order, node order and batch identity therefore no
+        longer depend on which worker happens to run first.
+        """
+        plans = []
+        global_index = 0
+
+        for document_index, item in enumerate(document_items):
+            soup = bs(item.content, "html.parser")
+            include_in_output = True
+            should_translate = True
+
+            if self.only_filelist and item.file_name not in self.only_filelist.split(
+                ","
+            ):
+                include_in_output = False
+                should_translate = False
+            elif (
+                not self.only_filelist
+                and item.file_name in self.exclude_filelist.split(",")
+            ):
+                should_translate = False
+
+            nodes = []
+            source_texts = []
+            if should_translate:
+                candidate_nodes = soup.find_all(trans_taglist)
+                candidate_nodes = self.filter_nest_list(candidate_nodes, trans_taglist)
+                if self.allow_navigable_strings:
+                    candidate_nodes.extend(soup.find_all(string=True))
+
+                for node in candidate_nodes:
+                    if self.is_test and global_index >= self.test_num:
+                        break
+                    source_text = self._translation_source_text(node)
+                    if not source_text or self._is_special_text(source_text):
+                        continue
+                    if self.accumulated_num > 1 and not_trans(source_text):
+                        continue
+                    if self._is_content_only_excluded_tags(node):
+                        continue
+                    nodes.append(node)
+                    source_texts.append(source_text)
+                    global_index += 1
+
+            first_global_index = global_index - len(nodes)
+            batch_indexes = self._assign_batch_indexes(source_texts)
+            jobs = []
+            for node_index, (node, source_text, batch_index) in enumerate(
+                zip(nodes, source_texts, batch_indexes)
+            ):
+                job_global_index = first_global_index + node_index
+                jobs.append(
+                    TranslationJob(
+                        job_id=self._translation_job_id(
+                            document_index,
+                            item.file_name,
+                            node_index,
+                            source_text,
+                        ),
+                        document_index=document_index,
+                        node_index=node_index,
+                        global_index=job_global_index,
+                        source_text=source_text,
+                        context_group=item.file_name,
+                        batch_index=batch_index,
+                        node=node,
+                    )
+                )
+
+            plans.append(
+                ChapterTranslationPlan(
+                    item=item,
+                    soup=soup,
+                    jobs=jobs,
+                    include_in_output=include_in_output,
+                )
+            )
+
+        return plans
+
     def process_item(
         self,
         item,
@@ -735,25 +888,32 @@ class EPUBBookLoader(BaseBookLoader):
         trans_taglist,
         fixstart=None,
         fixend=None,
+        chapter_plan=None,
     ):
-        if self.only_filelist != "" and item.file_name not in self.only_filelist.split(
-            ","
-        ):
-            return index
-        elif self.only_filelist == "" and item.file_name in self.exclude_filelist.split(
-            ","
-        ):
-            new_book.add_item(item)
-            return index
+        if chapter_plan is None:
+            if (
+                self.only_filelist != ""
+                and item.file_name not in self.only_filelist.split(",")
+            ):
+                return index
+            elif (
+                self.only_filelist == ""
+                and item.file_name in self.exclude_filelist.split(",")
+            ):
+                new_book.add_item(item)
+                return index
 
         if not os.path.exists("log"):
             os.makedirs("log")
 
-        content = item.content
-        soup = bs(content, "html.parser")
-        p_list = soup.findAll(trans_taglist)
-
-        p_list = self.filter_nest_list(p_list, trans_taglist)
+        if chapter_plan is None:
+            content = item.content
+            soup = bs(content, "html.parser")
+            p_list = soup.findAll(trans_taglist)
+            p_list = self.filter_nest_list(p_list, trans_taglist)
+        else:
+            soup = chapter_plan.soup
+            p_list = [job.node for job in chapter_plan.jobs]
 
         if self.retranslate:
             new_p_list = []
@@ -771,7 +931,7 @@ class EPUBBookLoader(BaseBookLoader):
                     p_list = new_p_list
                     break
 
-        if self.allow_navigable_strings:
+        if chapter_plan is None and self.allow_navigable_strings:
             p_list.extend(soup.findAll(text=True))
 
         send_num = self.accumulated_num
@@ -867,16 +1027,23 @@ class EPUBBookLoader(BaseBookLoader):
                 f"⚠️  Warning: {workers} workers is quite high. Consider using 2-8 workers for optimal performance."
             )
 
-    def _get_next_translation_index(self):
-        """Thread-safe method to get next translation index."""
+    def _record_translation_result(self, index, translated_text):
+        """Commit completed work as a document-ordered contiguous prefix."""
         with self._progress_lock:
-            index = self._translation_index
-            self._translation_index += 1
-            return index
+            if index < len(self.p_to_save):
+                return
+            self._pending_translation_results[index] = translated_text
+            while len(self.p_to_save) in self._pending_translation_results:
+                self.p_to_save.append(
+                    self._pending_translation_results.pop(len(self.p_to_save))
+                )
+            if len(self.p_to_save) // 20 > self._last_saved_progress // 20:
+                self._save_progress()
 
     def _process_chapter_parallel(self, chapter_data):
         """Process a single chapter in parallel mode with proper accumulated_num handling."""
-        item, trans_taglist, p_to_save_len = chapter_data
+        chapter_plan, p_to_save_len = chapter_data
+        item = chapter_plan.item
         chapter_result = {
             "item": item,
             "processed_content": None,
@@ -889,24 +1056,16 @@ class EPUBBookLoader(BaseBookLoader):
             # This ensures each chapter has its own independent context
             thread_translator = self._create_chapter_translator()
 
-            content = item.content
-            soup = bs(content, "html.parser")
-            p_list = soup.findAll(trans_taglist)
-            p_list = self.filter_nest_list(p_list, trans_taglist)
-
-            if self.allow_navigable_strings:
-                p_list.extend(soup.findAll(text=True))
+            soup = chapter_plan.soup
 
             # Initialize chapter-specific context lists
             chapter_context_list = []
             chapter_translated_list = []
 
-            # Apply accumulated_num logic for this chapter independently
             send_num = self.accumulated_num
             if send_num > 1:
-                # Use accumulated translation logic for this chapter
                 self._translate_paragraphs_acc_parallel(
-                    p_list,
+                    [job.node for job in chapter_plan.jobs],
                     send_num,
                     thread_translator,
                     chapter_context_list,
@@ -914,16 +1073,9 @@ class EPUBBookLoader(BaseBookLoader):
                 )
             else:
                 # Process paragraphs individually for this chapter
-                for p in p_list:
-                    if not p.text or self._is_special_text(p.text):
-                        continue
-
-                    # Skip paragraphs that only contain excluded tags (code, pre, etc.)
-                    if self._is_content_only_excluded_tags(p):
-                        continue
-
-                    new_p = self._extract_paragraph(copy(p))
-                    index = self._get_next_translation_index()
+                for job in chapter_plan.jobs:
+                    p = job.node
+                    index = job.global_index
 
                     if self.resume and index < p_to_save_len:
                         t_text = self.p_to_save[index]
@@ -931,13 +1083,12 @@ class EPUBBookLoader(BaseBookLoader):
                         # Use chapter-specific context for translation
                         t_text = self._translate_with_chapter_context(
                             thread_translator,
-                            new_p.text,
+                            job.source_text,
                             chapter_context_list,
                             chapter_translated_list,
                         )
                         t_text = "" if t_text is None else t_text
-                        with self._progress_lock:
-                            self.p_to_save.append(t_text)
+                        self._record_translation_result(index, t_text)
 
                     if isinstance(p, NavigableString):
                         translated_node = NavigableString(t_text)
@@ -948,10 +1099,6 @@ class EPUBBookLoader(BaseBookLoader):
                         self._insert_trans_preserving_tags(
                             p, t_text, self.translation_style, self.single_translate
                         )
-
-                    with self._progress_lock:
-                        if index % 20 == 0:
-                            self._save_progress()
 
             if soup:
                 chapter_result["processed_content"] = soup.encode(encoding="utf-8")
@@ -1167,11 +1314,24 @@ class EPUBBookLoader(BaseBookLoader):
 
         self.batch_init_then_wait()
         new_book = self._make_new_book(self.origin_book)
-        all_items = list(self.origin_book.get_items())
         trans_taglist = self.translate_tags.split(",")
+        document_items = list(self.origin_book.get_items_of_type(ITEM_DOCUMENT))
+        chapter_plans = self._build_translation_plan(document_items, trans_taglist)
+        self._planned_job_ids = [
+            job.job_id for plan in chapter_plans for job in plan.jobs
+        ]
+        if (
+            self.resume
+            and self._checkpoint_job_ids
+            != self._planned_job_ids[: len(self._checkpoint_job_ids)]
+        ):
+            raise ValueError(
+                "The EPUB or translation filters changed after the checkpoint; "
+                "delete the resume file and restart the translation"
+            )
 
-        # Count only paragraphs that actually need translation
-        all_p_length = self._count_translatable_paragraphs(all_items, trans_taglist)
+        # The plan is the single source of truth for progress and execution.
+        all_p_length = sum(len(plan.jobs) for plan in chapter_plans)
 
         # Use leave=False in test mode to prevent duplicate progress bar display
         pbar = tqdm(
@@ -1181,6 +1341,7 @@ class EPUBBookLoader(BaseBookLoader):
         print()
         index = 0
         p_to_save_len = len(self.p_to_save)
+        self._pending_translation_results = {}
         try:
             if self.retranslate:
                 self.retranslate_book(
@@ -1192,14 +1353,14 @@ class EPUBBookLoader(BaseBookLoader):
                 if item.get_type() != ITEM_DOCUMENT:
                     new_book.add_item(item)
 
-            document_items = list(self.origin_book.get_items_of_type(ITEM_DOCUMENT))
+            output_plans = [plan for plan in chapter_plans if plan.include_in_output]
 
-            if self.enable_parallel and len(document_items) > 1:
+            if self.enable_parallel and len(output_plans) > 1:
                 # Optimize worker count: no point having more workers than chapters
-                effective_workers = min(self.parallel_workers, len(document_items))
+                effective_workers = min(self.parallel_workers, len(output_plans))
 
                 # Parallel processing with proper accumulated_num handling
-                print(f"🚀 Parallel processing: {len(document_items)} chapters")
+                print(f"🚀 Parallel processing: {len(output_plans)} chapters")
                 if effective_workers < self.parallel_workers:
                     print(
                         f"📊 Optimized workers: {effective_workers} (reduced from {self.parallel_workers})"
@@ -1221,19 +1382,15 @@ class EPUBBookLoader(BaseBookLoader):
 
                 # Create a simpler progress bar for parallel processing
                 pbar.close()  # Close the original progress bar
-                chapter_pbar = tqdm(
-                    total=len(document_items), desc="Chapters", unit="ch"
-                )
+                chapter_pbar = tqdm(total=len(output_plans), desc="Chapters", unit="ch")
 
-                chapter_data_list = [
-                    (item, trans_taglist, p_to_save_len) for item in document_items
-                ]
+                chapter_data_list = [(plan, p_to_save_len) for plan in output_plans]
 
                 with ThreadPoolExecutor(max_workers=effective_workers) as executor:
                     future_to_item = {
                         executor.submit(
                             self._process_chapter_parallel, chapter_data
-                        ): chapter_data[0]
+                        ): chapter_data[0].item
                         for chapter_data in chapter_data_list
                     }
 
@@ -1263,13 +1420,16 @@ class EPUBBookLoader(BaseBookLoader):
                             chapter_pbar.update(1)
 
                 chapter_pbar.close()
-                print(f"✅ Completed all {len(document_items)} chapters")
+                print(f"✅ Completed all {len(output_plans)} chapters")
             else:
                 # Sequential processing (original behavior or single chapter)
-                if len(document_items) == 1 and self.enable_parallel:
+                if len(output_plans) == 1 and self.enable_parallel:
                     print(f"📄 Single chapter detected - using sequential processing")
 
-                for item in document_items:
+                for chapter_plan in chapter_plans:
+                    if not chapter_plan.include_in_output:
+                        continue
+                    item = chapter_plan.item
                     # Check for fatal error before processing each item
                     if self.translate_model._fatal_error_detected:
                         print(
@@ -1277,15 +1437,18 @@ class EPUBBookLoader(BaseBookLoader):
                         )
                         return
 
-                    # Continue processing all chapters (to add them to book)
-                    # but skip translation after test limit
-                    if self.is_test and index >= self.test_num:
-                        # Just add the chapter without translation
+                    if not chapter_plan.jobs:
                         new_book.add_item(item)
                         continue
 
                     index = self.process_item(
-                        item, index, p_to_save_len, pbar, new_book, trans_taglist
+                        item,
+                        index,
+                        p_to_save_len,
+                        pbar,
+                        new_book,
+                        trans_taglist,
+                        chapter_plan=chapter_plan,
                     )
 
                     # Check for fatal error after processing
@@ -1333,51 +1496,62 @@ class EPUBBookLoader(BaseBookLoader):
     def load_state(self):
         try:
             with open(self.bin_path, "rb") as f:
-                self.p_to_save = pickle.load(f)
+                state = pickle.load(f)
+            if (
+                not isinstance(state, dict)
+                or state.get("version") != self.CHECKPOINT_VERSION
+            ):
+                raise ValueError(
+                    "Legacy EPUB resume checkpoints cannot be safely reused; "
+                    f"delete {self.bin_path} and restart the translation"
+                )
+            if state.get("order") != self.CHECKPOINT_ORDER or not isinstance(
+                state.get("translations"), list
+            ):
+                raise ValueError("Invalid EPUB resume checkpoint")
+            if not isinstance(state.get("job_ids"), list) or len(
+                state["job_ids"]
+            ) != len(state["translations"]):
+                raise ValueError("Invalid EPUB resume checkpoint job identities")
+            self.p_to_save = state["translations"]
+            self._checkpoint_job_ids = state["job_ids"]
+            self._last_saved_progress = len(self.p_to_save)
+        except ValueError:
+            raise
         except Exception:
             raise Exception("can not load resume file")
 
     def _save_temp_book(self):
-        # TODO refactor this logic
         origin_book_temp = epub.read_epub(self.epub_name)
         new_temp_book = self._make_new_book(origin_book_temp)
-        p_to_save_len = len(self.p_to_save)
         trans_taglist = self.translate_tags.split(",")
-        index = 0
+        document_items = list(origin_book_temp.get_items_of_type(ITEM_DOCUMENT))
+        chapter_plans = iter(
+            self._build_translation_plan(document_items, trans_taglist)
+        )
         try:
             for item in origin_book_temp.get_items():
                 if item.get_type() == ITEM_DOCUMENT:
-                    content = item.content
-                    soup = bs(content, "html.parser")
-                    p_list = soup.findAll(trans_taglist)
-                    if self.allow_navigable_strings:
-                        p_list.extend(soup.findAll(text=True))
-                    for p in p_list:
-                        if not p.text or self._is_special_text(p.text):
-                            continue
-                        # Skip paragraphs that only contain excluded tags (code, pre, etc.)
-                        if self._is_content_only_excluded_tags(p):
-                            continue
-                        # TODO banch of p to translate then combine
-                        # PR welcome here
-                        if index < p_to_save_len:
-                            new_p = copy(p)
-                            if type(p) is NavigableString:
-                                new_p = self.p_to_save[index]
-                            else:
-                                new_p.string = self.p_to_save[index]
+                    chapter_plan = next(chapter_plans)
+                    if not chapter_plan.include_in_output:
+                        continue
+                    for job in chapter_plan.jobs:
+                        if job.global_index >= len(self.p_to_save):
+                            break
+                        translated_text = self.p_to_save[job.global_index]
+                        if isinstance(job.node, NavigableString):
+                            translated_node = NavigableString(translated_text)
+                            job.node.insert_after(translated_node)
+                            if self.single_translate:
+                                job.node.extract()
+                        else:
                             self._insert_trans_preserving_tags(
-                                p,
-                                new_p.string,
+                                job.node,
+                                translated_text,
                                 self.translation_style,
                                 self.single_translate,
                             )
-                            index += 1
-                        else:
-                            break
-                    # for save temp book
-                    if soup:
-                        item.content = soup.encode()
+                    item.content = chapter_plan.soup.encode()
                 new_temp_book.add_item(item)
             name, _ = os.path.splitext(self.epub_name)
             epub.write_epub(f"{name}_bilingual_temp.epub", new_temp_book, {})
@@ -1386,8 +1560,22 @@ class EPUBBookLoader(BaseBookLoader):
             print(e)
 
     def _save_progress(self):
+        completed_job_ids = self._planned_job_ids[: len(self.p_to_save)]
+        if len(completed_job_ids) != len(self.p_to_save):
+            raise ValueError(
+                "Cannot save EPUB progress before planning translation jobs"
+            )
         try:
             with open(self.bin_path, "wb") as f:
-                pickle.dump(self.p_to_save, f)
+                pickle.dump(
+                    {
+                        "version": self.CHECKPOINT_VERSION,
+                        "order": self.CHECKPOINT_ORDER,
+                        "job_ids": completed_job_ids,
+                        "translations": self.p_to_save,
+                    },
+                    f,
+                )
+            self._last_saved_progress = len(self.p_to_save)
         except Exception:
             raise Exception("can not save resume file")

--- a/tests/test_epub_loader_correctness.py
+++ b/tests/test_epub_loader_correctness.py
@@ -1,3 +1,4 @@
+import pickle
 import threading
 
 import pytest
@@ -72,6 +73,18 @@ class OrderedCompletionModel(RecordingModel):
             assert type(self).a_started.wait(timeout=2)
             type(self).b_finished.set()
         return f"<T>{text}</T>"
+
+
+class ParallelInterruptingModel(RecordingModel):
+    first_finished = threading.Event()
+
+    def translate(self, text):
+        if text == "chapter A":
+            result = super().translate(text)
+            type(self).first_finished.set()
+            return result
+        assert type(self).first_finished.wait(timeout=2)
+        raise KeyboardInterrupt
 
 
 class FailingModel(RecordingModel):
@@ -221,6 +234,45 @@ def test_epub_sequential_context_follows_document_order(tmp_path, monkeypatch):
     assert loader.translate_model.contexts_at_call == [[], ["one"], ["one", "two"]]
 
 
+def test_epub_translation_plan_has_stable_document_order_ids(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("a.xhtml", ["one", "two"]), ("b.xhtml", ["three"])],
+    )
+    document_items = list(loader.origin_book.get_items_of_type(ITEM_DOCUMENT))
+
+    first = loader._build_translation_plan(document_items, ["p"])
+    second = loader._build_translation_plan(document_items, ["p"])
+    first_jobs = [job for chapter in first for job in chapter.jobs]
+    second_jobs = [job for chapter in second for job in chapter.jobs]
+
+    assert [job.global_index for job in first_jobs] == [0, 1, 2]
+    assert [job.document_index for job in first_jobs] == [0, 0, 1]
+    assert [job.node_index for job in first_jobs] == [0, 1, 0]
+    assert [job.context_group for job in first_jobs] == [
+        "a.xhtml",
+        "a.xhtml",
+        "b.xhtml",
+    ]
+    assert [job.job_id for job in first_jobs] == [job.job_id for job in second_jobs]
+    assert len({job.job_id for job in first_jobs}) == 3
+
+
+def test_epub_translation_plan_assigns_stable_batch_indexes(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["one", "two", "three", "four", "five"])],
+    )
+    loader.block_size = 2
+    document_items = list(loader.origin_book.get_items_of_type(ITEM_DOCUMENT))
+
+    [chapter] = loader._build_translation_plan(document_items, ["p"])
+
+    assert [job.batch_index for job in chapter.jobs] == [0, 0, 1, 1, 2]
+
+
 def test_epub_sequential_accumulated_num_batches_in_document_order(
     tmp_path, monkeypatch
 ):
@@ -282,10 +334,6 @@ def test_epub_sequential_interrupt_and_resume_uses_completed_prefix(
         assert content.count(f"&lt;T&gt;{text}&lt;/T&gt;") == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="block_size translation sends text from inline excluded tags to the model",
-)
 def test_epub_sequential_batch_excludes_inline_code_content(tmp_path, monkeypatch):
     loader, _ = _make_loader(
         tmp_path,
@@ -315,10 +363,6 @@ def test_epub_sequential_translation_failure_exits_nonzero(tmp_path, monkeypatch
     assert exc.value.code != 0
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="parallel resume cache is appended in completion order, not document order",
-)
 def test_epub_parallel_checkpoint_order_is_deterministic(tmp_path, monkeypatch):
     OrderedCompletionModel.a_started.clear()
     OrderedCompletionModel.b_finished.clear()
@@ -335,10 +379,117 @@ def test_epub_parallel_checkpoint_order_is_deterministic(tmp_path, monkeypatch):
     assert loader.p_to_save == ["<T>chapter A</T>", "<T>chapter B</T>"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="parallel EPUB processing bypasses process_item file filtering",
-)
+def test_epub_parallel_rejects_legacy_completion_order_checkpoint(
+    tmp_path, monkeypatch
+):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("a.xhtml", ["chapter A"]), ("b.xhtml", ["chapter B"])],
+        parallel_workers=2,
+    )
+    with open(loader.bin_path, "wb") as checkpoint:
+        pickle.dump(["<T>chapter B</T>", "<T>chapter A</T>"], checkpoint)
+
+    with pytest.raises(ValueError, match="Legacy EPUB resume checkpoints"):
+        _make_loader(
+            tmp_path,
+            monkeypatch,
+            [("a.xhtml", ["chapter A"]), ("b.xhtml", ["chapter B"])],
+            resume=True,
+            parallel_workers=2,
+        )
+
+
+def test_epub_parallel_saves_when_committed_prefix_crosses_interval(
+    tmp_path, monkeypatch
+):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["one"])],
+        parallel_workers=2,
+    )
+    saved_lengths = []
+    monkeypatch.setattr(
+        loader, "_save_progress", lambda: saved_lengths.append(len(loader.p_to_save))
+    )
+
+    for index in range(1, 22):
+        loader._record_translation_result(index, str(index))
+    assert saved_lengths == []
+
+    loader._record_translation_result(0, "0")
+
+    assert len(loader.p_to_save) == 22
+    assert saved_lengths == [22]
+
+
+def test_epub_resume_rejects_changed_source_job_identity(tmp_path, monkeypatch):
+    chapters = [("one.xhtml", ["one", "two"])]
+    loader, _ = _make_loader(tmp_path, monkeypatch, chapters)
+    document_items = list(loader.origin_book.get_items_of_type(ITEM_DOCUMENT))
+    plans = loader._build_translation_plan(document_items, ["p"])
+    loader._planned_job_ids = [job.job_id for plan in plans for job in plan.jobs]
+    loader.p_to_save = ["<T>one</T>"]
+    loader._save_progress()
+
+    _write_epub(tmp_path / "book.epub", [("one.xhtml", ["changed", "two"])])
+    resumed, _ = _make_loader(tmp_path, monkeypatch, chapters, resume=True)
+
+    with pytest.raises(ValueError, match="EPUB or translation filters changed"):
+        resumed.make_bilingual_book()
+
+
+def test_epub_temp_book_replays_the_filtered_translation_plan(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("skip.xhtml", ["skip me"]), ("keep.xhtml", ["translate me"])],
+        parallel_workers=2,
+    )
+    loader.exclude_filelist = "skip.xhtml"
+    loader.p_to_save = ["<T>translate me</T>"]
+
+    loader._save_temp_book()
+
+    documents = _document_texts(tmp_path / "book_bilingual_temp.epub")
+    assert "&lt;T&gt;translate me&lt;/T&gt;" not in documents["skip.xhtml"]
+    assert "&lt;T&gt;translate me&lt;/T&gt;" in documents["keep.xhtml"]
+
+
+def test_epub_parallel_interrupt_resumes_from_contiguous_prefix(tmp_path, monkeypatch):
+    ParallelInterruptingModel.first_finished.clear()
+    chapters = [("a.xhtml", ["chapter A"]), ("b.xhtml", ["chapter B"])]
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        chapters,
+        model=ParallelInterruptingModel,
+        parallel_workers=2,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        loader.make_bilingual_book()
+    assert exc.value.code == 0
+    assert loader.p_to_save == ["<T>chapter A</T>"]
+
+    resumed, output = _make_loader(
+        tmp_path,
+        monkeypatch,
+        chapters,
+        model=RecordingModel,
+        resume=True,
+        parallel_workers=2,
+    )
+    resumed.make_bilingual_book()
+
+    assert resumed.translate_model.calls == ["chapter B"]
+    documents = _document_texts(output)
+    assert documents["a.xhtml"].count("&lt;T&gt;chapter A&lt;/T&gt;") == 1
+    assert documents["b.xhtml"].count("&lt;T&gt;chapter B&lt;/T&gt;") == 1
+
+
 def test_epub_parallel_honors_excluded_files(tmp_path, monkeypatch):
     loader, _ = _make_loader(
         tmp_path,
@@ -353,10 +504,6 @@ def test_epub_parallel_honors_excluded_files(tmp_path, monkeypatch):
     assert loader.translate_model.calls == ["translate me"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="parallel EPUB processing does not enforce the global test_num limit",
-)
 def test_epub_parallel_test_num_limits_requests(tmp_path, monkeypatch):
     loader, _ = _make_loader(
         tmp_path,
@@ -414,7 +561,7 @@ def test_epub_parallel_propagates_chapter_failures(tmp_path, monkeypatch):
 
 @pytest.mark.xfail(
     strict=True,
-    reason="parallel EPUB processing bypasses block_size batch translation",
+    reason="parallel EPUB processing still bypasses block_size batch translation",
 )
 def test_epub_parallel_honors_block_size(tmp_path, monkeypatch):
     loader, _ = _make_loader(

--- a/tests/test_epub_loader_correctness.py
+++ b/tests/test_epub_loader_correctness.py
@@ -1,0 +1,434 @@
+import threading
+
+import pytest
+from ebooklib import ITEM_DOCUMENT, epub
+
+from book_maker.loader.epub_loader import EPUBBookLoader
+
+
+class RecordingModel:
+    instances = []
+    TRANSLATION_ERROR_MARKER = "[Translation unavailable]"
+
+    def __init__(
+        self,
+        key,
+        language,
+        api_base=None,
+        context_flag=False,
+        context_paragraph_limit=0,
+        temperature=1.0,
+        source_lang="auto",
+        **kwargs,
+    ):
+        self.calls = []
+        self.list_calls = []
+        self.contexts_at_call = []
+        self.context_flag = context_flag
+        self.context_paragraph_limit = context_paragraph_limit or 3
+        self.context_list = []
+        self.context_translated_list = []
+        self._fatal_error_detected = False
+        type(self).instances.append(self)
+
+    def translate(self, text):
+        self.calls.append(text)
+        self.contexts_at_call.append(list(self.context_list))
+        translated = f"<T>{text}</T>"
+        if self.context_flag:
+            self.context_list.append(text)
+            self.context_translated_list.append(translated)
+            self.context_list = self.context_list[-self.context_paragraph_limit :]
+            self.context_translated_list = self.context_translated_list[
+                -self.context_paragraph_limit :
+            ]
+        return translated
+
+    def translate_list(self, texts):
+        plain_texts = [str(text) for text in texts]
+        self.list_calls.append(plain_texts)
+        return [self.translate(text) for text in plain_texts]
+
+
+class InterruptingModel(RecordingModel):
+    def translate(self, text):
+        if self.calls:
+            raise KeyboardInterrupt
+        return super().translate(text)
+
+
+class OrderedCompletionModel(RecordingModel):
+    """Make chapter B finish before chapter A after A obtained index zero."""
+
+    a_started = threading.Event()
+    b_finished = threading.Event()
+
+    def translate(self, text):
+        self.calls.append(text)
+        if text == "chapter A":
+            type(self).a_started.set()
+            assert type(self).b_finished.wait(timeout=2)
+        elif text == "chapter B":
+            assert type(self).a_started.wait(timeout=2)
+            type(self).b_finished.set()
+        return f"<T>{text}</T>"
+
+
+class FailingModel(RecordingModel):
+    def translate(self, text):
+        raise RuntimeError(f"cannot translate {text}")
+
+
+def _write_epub(path, chapters):
+    book = epub.EpubBook()
+    book.set_identifier("correctness-baseline")
+    book.set_title("Correctness baseline")
+    book.set_language("en")
+
+    items = []
+    for index, (file_name, paragraphs) in enumerate(chapters):
+        item = epub.EpubHtml(
+            title=f"Chapter {index + 1}", file_name=file_name, lang="en"
+        )
+        body = "".join(f"<p>{paragraph}</p>" for paragraph in paragraphs)
+        item.content = f"<html><body>{body}</body></html>"
+        book.add_item(item)
+        items.append(item)
+
+    book.toc = tuple(items)
+    book.spine = items
+    epub.write_epub(str(path), book)
+
+
+def _make_loader(
+    tmp_path,
+    monkeypatch,
+    chapters,
+    model=RecordingModel,
+    *,
+    resume=False,
+    parallel_workers=1,
+    context_flag=False,
+    is_test=False,
+    test_num=5,
+):
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "book.epub"
+    if not source.exists():
+        _write_epub(source, chapters)
+
+    loader = EPUBBookLoader(
+        str(source),
+        model,
+        key="",
+        resume=resume,
+        language="zh-hans",
+        context_flag=context_flag,
+        context_paragraph_limit=3,
+        parallel_workers=parallel_workers,
+        is_test=is_test,
+        test_num=test_num,
+    )
+    return loader, source.with_name("book_bilingual.epub")
+
+
+def _document_texts(path):
+    book = epub.read_epub(str(path))
+    return {
+        item.file_name: item.get_body_content().decode("utf-8")
+        for item in book.get_items_of_type(ITEM_DOCUMENT)
+    }
+
+
+def test_epub_sequential_bilingual_output_preserves_source(tmp_path, monkeypatch):
+    loader, output = _make_loader(
+        tmp_path, monkeypatch, [("one.xhtml", ["one", "two"])]
+    )
+
+    loader.make_bilingual_book()
+
+    content = _document_texts(output)["one.xhtml"]
+    assert content.index("one") < content.index("&lt;T&gt;one&lt;/T&gt;")
+    assert content.index("two") < content.index("&lt;T&gt;two&lt;/T&gt;")
+
+
+def test_epub_sequential_single_translate_removes_source(tmp_path, monkeypatch):
+    loader, output = _make_loader(
+        tmp_path, monkeypatch, [("one.xhtml", ["source only"])]
+    )
+    loader.single_translate = True
+
+    loader.make_bilingual_book()
+
+    content = _document_texts(output)["one.xhtml"]
+    assert content.count("<p>") == 1
+    assert "&lt;T&gt;source only&lt;/T&gt;" in content
+
+
+def test_epub_sequential_honors_excluded_files(tmp_path, monkeypatch):
+    loader, output = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("keep.xhtml", ["translate me"]), ("skip.xhtml", ["do not translate"])],
+    )
+    loader.exclude_filelist = "skip.xhtml"
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.calls == ["translate me"]
+    documents = _document_texts(output)
+    assert "&lt;T&gt;translate me&lt;/T&gt;" in documents["keep.xhtml"]
+    assert "&lt;T&gt;do not translate&lt;/T&gt;" not in documents["skip.xhtml"]
+
+
+def test_epub_sequential_honors_only_filelist(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("keep.xhtml", ["translate me"]), ("skip.xhtml", ["do not translate"])],
+    )
+    loader.only_filelist = "keep.xhtml"
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.calls == ["translate me"]
+
+
+def test_epub_sequential_test_num_limits_requests(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["one", "two", "three"])],
+        is_test=True,
+        test_num=2,
+    )
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.calls == ["one", "two"]
+
+
+def test_epub_sequential_context_follows_document_order(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["one", "two", "three"])],
+        context_flag=True,
+    )
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.contexts_at_call == [[], ["one"], ["one", "two"]]
+
+
+def test_epub_sequential_accumulated_num_batches_in_document_order(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("book_maker.loader.epub_loader.num_tokens_from_text", len)
+    loader, output = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["one", "two", "three"])],
+    )
+    loader.accumulated_num = 100
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.list_calls == [["one", "two", "three"]]
+    content = _document_texts(output)["one.xhtml"]
+    for text in ("one", "two", "three"):
+        assert content.count(f"&lt;T&gt;{text}&lt;/T&gt;") == 1
+
+
+def test_epub_sequential_sentence_mode_preserves_sentence_order(tmp_path, monkeypatch):
+    loader, output = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["First sentence. Second sentence."])],
+    )
+    loader.sentence_mode = True
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.list_calls == [
+        ["First sentence.", "Second sentence."]
+    ]
+    content = _document_texts(output)["one.xhtml"]
+    assert content.index("First sentence.") < content.index("Second sentence.")
+    assert content.index("&lt;T&gt;First sentence.&lt;/T&gt;") < content.index(
+        "&lt;T&gt;Second sentence.&lt;/T&gt;"
+    )
+
+
+def test_epub_sequential_interrupt_and_resume_uses_completed_prefix(
+    tmp_path, monkeypatch
+):
+    chapters = [("one.xhtml", ["one", "two", "three"])]
+    loader, _ = _make_loader(tmp_path, monkeypatch, chapters, model=InterruptingModel)
+
+    with pytest.raises(SystemExit) as exc:
+        loader.make_bilingual_book()
+    assert exc.value.code == 0
+    assert loader.p_to_save == ["<T>one</T>"]
+
+    resumed, output = _make_loader(
+        tmp_path, monkeypatch, chapters, model=RecordingModel, resume=True
+    )
+    resumed.make_bilingual_book()
+
+    assert resumed.translate_model.calls == ["two", "three"]
+    content = _document_texts(output)["one.xhtml"]
+    for text in ("one", "two", "three"):
+        assert content.count(f"&lt;T&gt;{text}&lt;/T&gt;") == 1
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="block_size translation sends text from inline excluded tags to the model",
+)
+def test_epub_sequential_batch_excludes_inline_code_content(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["before <code>secret()</code> after"])],
+    )
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.calls == ["before  after"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="sequential translation errors currently terminate with a success exit code",
+)
+def test_epub_sequential_translation_failure_exits_nonzero(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("one.xhtml", ["one"])],
+        model=FailingModel,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        loader.make_bilingual_book()
+    assert exc.value.code != 0
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="parallel resume cache is appended in completion order, not document order",
+)
+def test_epub_parallel_checkpoint_order_is_deterministic(tmp_path, monkeypatch):
+    OrderedCompletionModel.a_started.clear()
+    OrderedCompletionModel.b_finished.clear()
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("a.xhtml", ["chapter A"]), ("b.xhtml", ["chapter B"])],
+        model=OrderedCompletionModel,
+        parallel_workers=2,
+    )
+
+    loader.make_bilingual_book()
+
+    assert loader.p_to_save == ["<T>chapter A</T>", "<T>chapter B</T>"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="parallel EPUB processing bypasses process_item file filtering",
+)
+def test_epub_parallel_honors_excluded_files(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("keep.xhtml", ["translate me"]), ("skip.xhtml", ["do not translate"])],
+        parallel_workers=2,
+    )
+    loader.exclude_filelist = "skip.xhtml"
+
+    loader.make_bilingual_book()
+
+    assert loader.translate_model.calls == ["translate me"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="parallel EPUB processing does not enforce the global test_num limit",
+)
+def test_epub_parallel_test_num_limits_requests(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("a.xhtml", ["one", "two"]), ("b.xhtml", ["three", "four"])],
+        parallel_workers=2,
+        is_test=True,
+        test_num=1,
+    )
+
+    loader.make_bilingual_book()
+
+    assert len(loader.translate_model.calls) == 1
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="EPUB chapters currently share the same mutable translator instance",
+)
+def test_epub_parallel_creates_an_isolated_translator_per_chapter(
+    tmp_path, monkeypatch
+):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("a.xhtml", ["one"]), ("b.xhtml", ["two"])],
+        parallel_workers=2,
+        context_flag=True,
+    )
+
+    first = loader._create_chapter_translator()
+    second = loader._create_chapter_translator()
+
+    assert first is not loader.translate_model
+    assert second is not loader.translate_model
+    assert first is not second
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="parallel chapter errors are swallowed and the original chapter is emitted",
+)
+def test_epub_parallel_propagates_chapter_failures(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("a.xhtml", ["one"]), ("b.xhtml", ["two"])],
+        model=FailingModel,
+        parallel_workers=2,
+    )
+
+    with pytest.raises(RuntimeError, match="cannot translate"):
+        loader.make_bilingual_book()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="parallel EPUB processing bypasses block_size batch translation",
+)
+def test_epub_parallel_honors_block_size(tmp_path, monkeypatch):
+    loader, _ = _make_loader(
+        tmp_path,
+        monkeypatch,
+        [("a.xhtml", ["one", "two"]), ("b.xhtml", ["three", "four"])],
+        parallel_workers=2,
+    )
+    loader.block_size = 2
+
+    loader.make_bilingual_book()
+
+    assert sorted(loader.translate_model.list_calls) == [
+        ["one", "two"],
+        ["three", "four"],
+    ]
+    assert sorted(loader.translate_model.calls) == ["four", "one", "three", "two"]


### PR DESCRIPTION
## Summary

- precompute stable, document-ordered EPUB translation jobs before sequential or parallel execution
- persist versioned checkpoint metadata with job identities and reject incompatible or legacy resume files
- commit parallel results only as a contiguous prefix and save whenever progress crosses a checkpoint interval
- reconstruct temporary EPUBs from the same filtered translation plan used during execution
- add correctness coverage for ordering, filtering, interrupted resumes, checkpoint validation, and batching identity

## Why

Parallel chapter workers previously allowed completion order to determine checkpoint positions. That could associate cached translations with the wrong source paragraphs, especially after interruption, when filters changed, or when temporary books replayed a different document set. Exact-modulo persistence could also miss checkpoint boundaries when several pending results became contiguous at once.

The new translation plan assigns stable job identities and document-order indexes before requests begin, making execution order independent from resume and cache identity.

## Impact

- parallel EPUB output and resume state remain deterministic across out-of-order chapter completion
- changed EPUB content or translation filters fail safely instead of silently reusing positional translations
- legacy checkpoints are explicitly rejected because their completion ordering cannot be migrated safely
- excluded documents remain excluded when generating interrupted temporary books

## Validation

`env PYTHONPATH=. .venv/bin/pytest -q tests/test_epub_loader_correctness.py`

Result: 20 passed, 4 xfailed.
