### PR TITLE
fix(epub): 让翻译产物保持合法的 EPUB 3

### DIFF
--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -27,7 +27,15 @@ from tqdm import tqdm
 from book_maker.utils import num_tokens_from_text, prompt_config_to_kwargs
 
 from .base_loader import BaseBookLoader
-from .helper import EPUBBookLoaderHelper, is_text_link, not_trans, shorter_result_link
+from .helper import (
+    EPUBBookLoaderHelper,
+    append_inline_translation,
+    has_restricted_content_model,
+    is_text_link,
+    not_trans,
+    shorter_result_link,
+    strip_duplicate_ids,
+)
 from .plan import (
     PLAN_SCHEMA_VERSION,
     BookCss,
@@ -221,6 +229,12 @@ class EPUBBookLoader(BaseBookLoader):
 
     def _make_new_book(self, book):
         new_book = epub.EpubBook()
+        # ebooklib always writes <spine toc="ncx">, so a book without an NCX
+        # item leaves that reference dangling (epubcheck OPF-049). Adding the
+        # item — uid "ncx", which is what the attribute names — both resolves
+        # it and restores the EPUB 2 fallback table of contents.
+        if not any(isinstance(item, epub.EpubNcx) for item in book.get_items()):
+            new_book.add_item(epub.EpubNcx())
         # add_metadata() does not populate the scalar fields consumed by
         # ebooklib's generated navigation document.
         new_book.title = book.title
@@ -258,6 +272,15 @@ class EPUBBookLoader(BaseBookLoader):
                         continue
                 else:
                     # Unexpected metadata format; skip gracefully
+                    continue
+
+                if name == "link":
+                    # ebooklib parses OPF <link rel=… href=…> into metadata
+                    # but writes every metadata entry back as <meta>, where
+                    # rel/href are not legal attributes — the book then
+                    # fails validation (RSC-005) over an accessibility
+                    # statement it merely copied. Dropping the link loses a
+                    # pointer; keeping it loses the book.
                     continue
 
                 # `others` can be {} or None
@@ -839,12 +862,17 @@ class EPUBBookLoader(BaseBookLoader):
                 p.append(copy(content))
         else:
             # Bilingual mode: keep original paragraph with code, add translation after
+            if has_restricted_content_model(p):
+                append_inline_translation(p, translated_text, translation_style)
+                return
             new_p = copy(p)
             # Remove code tags from translation
             for tag_name in exclude_tags_list:
                 for tag in new_p.find_all(tag_name):
                     tag.extract()
             new_p.string = translated_text
+            # a translated copy is a second rendering, not a second anchor
+            strip_duplicate_ids(new_p)
             if translation_style != "":
                 new_p["style"] = translation_style
             p.insert_after(new_p)

--- a/book_maker/loader/helper.py
+++ b/book_maker/loader/helper.py
@@ -3,8 +3,75 @@ import backoff
 import logging
 from copy import copy
 
+from bs4.element import Tag
+
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
+
+# Elements whose parent accepts exactly one of them, and containers with a
+# content model too strict for an appended sibling. A translated copy next
+# to one of these is a book epubcheck rejects: <figure> takes one
+# <figcaption>, and an EPUB 3 navigation document takes one heading before
+# its <ol> and nothing but <a>/<span> inside an <li>.
+SINGLETON_TAGS = frozenset(["figcaption", "caption", "legend", "summary"])
+
+
+def strip_duplicate_ids(element):
+    """Remove every id from a cloned element and its descendants.
+
+    A translated copy is a second rendering of the same content, not a
+    second anchor for it. Leaving the ids in produces a document where two
+    elements answer to one fragment identifier — epubcheck RSC-005, and an
+    internal cross-reference that may land on the translation instead of
+    the passage it cites.
+    """
+    if isinstance(element, Tag):
+        element.attrs.pop("id", None)
+        for descendant in element.descendants:
+            if isinstance(descendant, Tag):
+                descendant.attrs.pop("id", None)
+    return element
+
+
+def has_restricted_content_model(element):
+    """Would a translated sibling of this element be invalid markup?"""
+    if element.name in SINGLETON_TAGS:
+        return True
+    return element.find_parent("nav") is not None
+
+
+def translation_host(element):
+    """Which element a translation may be appended to.
+
+    Usually the element itself. An EPUB 3 navigation <li> is the exception:
+    its entire content model is "(a | span), ol?", so a translation
+    appended to the <li> is exactly as invalid as one placed beside it —
+    epubcheck rejects both with "element span not allowed here". The text
+    an entry shows lives in its <a>/<span>, and so does its translation.
+    """
+    if element.name == "li" and element.find_parent("nav") is not None:
+        label = element.find(["a", "span"], recursive=False)
+        if label is not None:
+            return label
+    return element
+
+
+def append_inline_translation(element, text, translation_style=""):
+    """Put the translation *inside* the element it belongs to.
+
+    Some containers accept exactly one of a thing: an EPUB 3 navigation
+    document allows one heading before its <ol> and nothing but <a>/<span>
+    inside an <li>; a <figure> allows one <figcaption>. Appending a
+    translated sibling there produces a book epubcheck rejects, so the
+    translation joins the element's own content instead — a table-of-
+    contents entry reads "Chapter 1 第一章" and stays valid.
+    """
+    span = Tag(name="span")
+    if translation_style:
+        span["style"] = translation_style
+    span.string = f" {text}"
+    translation_host(element).append(span)
+    return span
 
 
 class EPUBBookLoaderHelper:
@@ -24,10 +91,23 @@ class EPUBBookLoaderHelper:
             and p.string.replace(" ", "").strip() == text.replace(" ", "").strip()
         ):
             return
+        if not single_translate and has_restricted_content_model(p):
+            # single-translate extracts the original, so it never creates
+            # the second sibling this rule exists to prevent
+            append_inline_translation(p, text, translation_style)
+            return
         new_p = copy(p)
         new_p.string = text
         if translation_style != "":
             new_p["style"] = translation_style
+        if not single_translate:
+            # The copy would otherwise carry the original's id and every id
+            # inside it, so the document ends up with two elements answering
+            # to the same anchor: epubcheck rejects it (RSC-005), and an
+            # internal link may land on the translation instead of the text
+            # it points at. When the original is extracted there is no
+            # duplicate, so single-translate keeps its ids.
+            strip_duplicate_ids(new_p)
         p.insert_after(new_p)
         if single_translate:
             p.extract()

--- a/tests/test_epub_output_validity.py
+++ b/tests/test_epub_output_validity.py
@@ -1,0 +1,271 @@
+"""The output must be a valid EPUB, not merely a translated one.
+
+Every case here reproduces an epubcheck finding that the unfixed code
+produced on the IDPF/W3C epub3-samples books — the codes are named in the
+docstrings so a failure points straight at what a reading system would
+reject.
+"""
+
+import zipfile
+from copy import copy
+
+from bs4 import BeautifulSoup as bs
+from ebooklib import epub
+
+from book_maker.loader.epub_loader import EPUBBookLoader
+from book_maker.loader.helper import EPUBBookLoaderHelper, strip_duplicate_ids
+
+
+def _helper():
+    return EPUBBookLoaderHelper(None, None, "", False)
+
+
+def _soup(html):
+    return bs(html, "html.parser")
+
+
+def _loader():
+    """A loader with only what the insertion paths touch."""
+    loader = EPUBBookLoader.__new__(EPUBBookLoader)
+    loader.translate_model = type("M", (), {"TRANSLATION_ERROR_MARKER": None})()
+    loader.exclude_translate_tags = "sup,code"
+    loader.helper = _helper()
+    return loader
+
+
+# ----------------------------------------------------------- duplicate ids
+
+
+def test_bilingual_clone_carries_no_id():
+    """RSC-005 "Duplicate ID": the clone must not answer to the original's
+    fragment identifier, or an internal link may land on the translation."""
+    soup = _soup('<body><p id="c1_h">Chapter One</p></body>')
+    p = soup.find("p")
+    _helper().insert_trans(p, "第一章")
+
+    paragraphs = soup.find_all("p")
+    assert len(paragraphs) == 2
+    assert paragraphs[0].get("id") == "c1_h"
+    assert paragraphs[1].get("id") is None
+
+
+def test_the_original_keeps_every_anchor_it_had():
+    soup = _soup('<body><p id="p1">See <a id="ref1" href="#x">note</a>.</p></body>')
+    _helper().insert_trans(soup.find("p"), "翻译")
+
+    original, translation = soup.find_all("p")
+    assert original.get("id") == "p1"
+    assert original.find("a").get("id") == "ref1"
+    assert translation.get("id") is None
+
+
+def test_strip_duplicate_ids_clears_the_whole_subtree():
+    """The clone's own text is replaced today, so only its outer id can
+    survive — but the helper is what guarantees a clone is never a second
+    anchor, and it has to hold for a caller that keeps the children."""
+    soup = _soup('<div id="d1"><p id="p1"><a id="a1" href="#x">note</a></p></div>')
+    stripped = strip_duplicate_ids(copy(soup.find("div")))
+
+    assert stripped.get("id") is None
+    assert [tag.get("id") for tag in stripped.find_all(True)] == [None, None]
+    # the source is untouched
+    assert soup.find("div").get("id") == "d1"
+
+
+def test_single_translate_keeps_the_original_ids():
+    """The original is extracted, so nothing is duplicated and the book's
+    own anchors must survive — dropping them would break every link."""
+    soup = _soup('<body><p id="c1_h">Chapter One</p></body>')
+    _helper().insert_trans(soup.find("p"), "第一章", single_translate=True)
+
+    paragraphs = soup.find_all("p")
+    assert len(paragraphs) == 1
+    assert paragraphs[0].get("id") == "c1_h"
+    assert paragraphs[0].get_text() == "第一章"
+
+
+# ------------------------------------------------- restricted content models
+
+
+def test_figcaption_translation_stays_inside_the_caption():
+    """RSC-005: a <figure> accepts one <figcaption>; a translated sibling
+    gives it two."""
+    soup = _soup(
+        "<body><figure><img src='x.png' alt=''/>"
+        "<figcaption>Figure 1. A tree</figcaption></figure></body>"
+    )
+    _helper().insert_trans(soup.find("figcaption"), "图1。一棵树")
+
+    figure = soup.find("figure")
+    assert len(figure.find_all("figcaption")) == 1
+    assert "图1。一棵树" in figure.find("figcaption").get_text()
+
+
+def test_nav_link_translation_goes_inside_the_link():
+    """RSC-005: an EPUB 3 nav <li> accepts "(a | span), ol?" — a second <a>
+    beside the first is invalid."""
+    soup = _soup(
+        "<body><nav epub:type='toc'><ol>"
+        "<li><a href='ch01.xhtml'>Chapter One</a></li>"
+        "</ol></nav></body>"
+    )
+    _helper().insert_trans(soup.find("a"), "第一章")
+
+    li = soup.find("li")
+    assert len(li.find_all("a")) == 1
+    assert li.get_text().split() == ["Chapter", "One", "第一章"]
+
+
+def test_nav_list_item_translation_goes_inside_its_link_not_after_the_sublist():
+    """The whole <li> is the translatable owner when a partition owns the
+    entry's text. Appending to the <li> is as invalid as a sibling: with a
+    nested <ol> present, epubcheck reports "element span not allowed here;
+    expected the element end-tag or element ol". The entry's text lives in
+    its <a>, and so does its translation.
+    """
+    soup = _soup(
+        "<body><nav epub:type='toc'><ol>"
+        "<li><a href='pr01.xhtml'>Preface</a>"
+        "<ol><li><a href='pr01s02.xhtml'>Acknowledgments</a></li></ol>"
+        "</li></ol></nav></body>"
+    )
+    outer = soup.find("li")
+    _helper().insert_trans(outer.find("a", recursive=False), "前言")
+
+    # the translation is inside the entry's own link …
+    assert outer.find("a", recursive=False).get_text() == "Preface 前言"
+    # … and the <li>'s direct children are still exactly (a, ol)
+    assert [c.name for c in outer.find_all(recursive=False)] == ["a", "ol"]
+
+
+def test_nav_list_item_owner_targets_its_link():
+    """Same shape, but the caller hands over the <li> itself — which is what
+    a whole-block partition does."""
+    soup = _soup(
+        "<body><nav epub:type='toc'><ol>"
+        "<li><a href='pr01.xhtml'>Preface</a>"
+        "<ol><li><a href='pr01s02.xhtml'>Acknowledgments</a></li></ol>"
+        "</li></ol></nav></body>"
+    )
+    outer = soup.find("li")
+    _helper().insert_trans(outer, "前言")
+
+    assert [c.name for c in outer.find_all(recursive=False)] == ["a", "ol"]
+    assert outer.find("a", recursive=False).get_text() == "Preface 前言"
+
+
+def test_nav_heading_keeps_its_translation_inside():
+    """A nav document allows one heading before its <ol>."""
+    soup = _soup(
+        "<body><nav epub:type='toc'><h2>Table of Contents</h2>"
+        "<ol><li><a href='ch01.xhtml'>One</a></li></ol></nav></body>"
+    )
+    _helper().insert_trans(soup.find("h2"), "目录")
+
+    nav = soup.find("nav")
+    assert len(nav.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])) == 1
+    assert "目录" in nav.find("h2").get_text()
+
+
+def test_an_ordinary_paragraph_still_gets_a_translated_sibling():
+    """The rule must not overreach: everywhere else, bilingual output is a
+    second block, which is what makes it readable side by side."""
+    soup = _soup("<body><p>Chapter One</p></body>")
+    _helper().insert_trans(soup.find("p"), "第一章")
+
+    assert [p.get_text() for p in soup.find_all("p")] == ["Chapter One", "第一章"]
+
+
+def test_a_figcaption_outside_a_figure_is_still_treated_as_a_singleton():
+    soup = _soup("<body><figcaption>Figure 1</figcaption></body>")
+    _helper().insert_trans(soup.find("figcaption"), "图1")
+
+    assert len(soup.find_all("figcaption")) == 1
+
+
+# ------------------------------------------- the excluded-tag insertion path
+
+
+def test_preserving_tags_path_drops_ids_on_the_clone():
+    """The code-tag branch clones the paragraph itself, so it needs the
+    same treatment as the plain path."""
+    loader = _loader()
+    soup = _soup('<body><p id="p1">Run <code>ls</code> first.</p></body>')
+    loader._insert_trans_preserving_tags(soup.find("p"), "先运行")
+
+    paragraphs = soup.find_all("p")
+    assert len(paragraphs) == 2
+    assert paragraphs[1].get("id") is None
+    assert paragraphs[1].find("code") is None
+
+
+def test_preserving_tags_path_respects_restricted_containers():
+    loader = _loader()
+    soup = _soup(
+        "<body><figure><figcaption>Listing <code>ls</code> 1</figcaption>"
+        "</figure></body>"
+    )
+    loader._insert_trans_preserving_tags(soup.find("figcaption"), "清单1")
+
+    assert len(soup.find("figure").find_all("figcaption")) == 1
+    assert "清单1" in soup.get_text()
+
+
+# --------------------------------------------------------------- the OPF
+
+
+def test_new_book_gets_an_ncx_when_the_source_has_none(tmp_path):
+    """OPF-049 "Item id ncx was not found in the manifest": ebooklib always
+    writes <spine toc="ncx">, so the reference dangles without the item."""
+    source = epub.EpubBook()
+    source.set_title("No NCX Here")
+    source.set_language("en")
+
+    rebuilt = EPUBBookLoader.__new__(EPUBBookLoader)._make_new_book(source)
+
+    assert [i for i in rebuilt.get_items() if isinstance(i, epub.EpubNcx)]
+
+
+def test_new_book_does_not_add_a_second_ncx(tmp_path):
+    source = epub.EpubBook()
+    source.set_title("Has NCX")
+    source.set_language("en")
+    source.add_item(epub.EpubNcx())
+
+    rebuilt = EPUBBookLoader.__new__(EPUBBookLoader)._make_new_book(source)
+
+    assert len([i for i in rebuilt.get_items() if isinstance(i, epub.EpubNcx)]) <= 1
+
+
+def test_link_metadata_is_dropped_rather_than_written_as_meta(tmp_path):
+    """RSC-005 'attribute "rel" not allowed here': ebooklib parses OPF
+    <link rel=… href=…> into metadata but writes it back as <meta>, where
+    neither attribute is legal."""
+    source = epub.EpubBook()
+    source.set_title("Linked")
+    source.set_language("en")
+    # the shape ebooklib's reader produces for <link rel=… href=…>: the OPF
+    # namespace, a null value, and the attributes in `others`. Building it
+    # under any other namespace would be dropped by the namespace filter
+    # instead, and the test would pass without exercising this rule.
+    source.add_metadata(
+        epub.NAMESPACES["OPF"],
+        "link",
+        None,
+        {
+            "rel": "dcterms:conformsTo",
+            "href": "http://www.idpf.org/epub/a11y/accessibility-20170105.html",
+        },
+    )
+
+    rebuilt = EPUBBookLoader.__new__(EPUBBookLoader)._make_new_book(source)
+
+    for namespace, entries in rebuilt.metadata.items():
+        assert "link" not in entries, f"link metadata survived in {namespace!r}"
+
+    out = tmp_path / "linked.epub"
+    epub.write_epub(str(out), rebuilt)
+    with zipfile.ZipFile(out) as book:
+        opf = next(n for n in book.namelist() if n.endswith(".opf"))
+        content = book.read(opf).decode("utf-8")
+    assert 'rel="dcterms:conformsTo"' not in content


### PR DESCRIPTION
## 问题：翻译会给输出引入源书本身没有的 EPUB 校验错误

三个成因，全部位于**写出输出**的代码里，而不是翻译逻辑里；全部可以在 IDPF/W3C 的 [epub3-samples](https://github.com/IDPF/epub3-samples) 上用 epubcheck 5.3.0 复现。

### 1. 重复 id（RSC-005）

双语插入用 `copy(p)` 克隆源元素，克隆体连同原来的 `id`、以及它内部所有元素的 id 一起被复制。于是同一个片段标识符有两个元素回应，书内的交叉引用可能落到译文上，而不是它引用的那段原文。`jlreq-in-english.epub`：62 个 error。

### 2. 受限容器的内容模型（RSC-005）

`<figure>` 只接受一个 `<figcaption>`；EPUB 3 导航文档在 `<ol>` 之前只接受一个标题，`<li>` 的内容模型是 `(a | span), ol?`。在这些位置插入一个「译文兄弟节点」就是非法标记。

现在译文改为并入元素自身的内容——目录项读作「Chapter 1 第一章」并保持合法。导航 `<li>` 的译文放进条目的 `<a>`/`<span>` 里面：因为 `<li>` 的内容模型如上，直接追加到 `<li>` 上和插兄弟节点一样非法。

### 3. spine 的 toc 悬空引用（OPF-049）与 `<link>` 元数据（RSC-005）

ebooklib 总是写 `<spine toc="ncx">`，所以源书没有 NCX 时，输出就带着一个指向不存在 manifest 项的引用；补上该项同时也恢复了 EPUB 2 的后备目录。

另外，ebooklib 会把 OPF 的 `<link rel=… href=…>` 解析进 metadata，却把每一条 metadata 都按 `<meta>` 写回，而这两个属性在 `<meta>` 上都不合法——于是一本书会仅仅因为原样复制了一份无障碍声明而校验失败。

## 实现

插入规则集中在 `book_maker/loader/helper.py`，并在两处克隆段落的地方同时应用（`helper.insert_trans`，以及 `_insert_trans_preserving_tags` 的排除标签分支），因此标签模式与 `--plan-classify` 计划模式共用同一套规则。

## 实测（epubcheck 5.3.0；`accessible_epub_3.epub` 源书本身 0 error）

| 命令 | 修复前 → 修复后 |
| --- | --- |
| `--translate-tags p`（默认） | 5 → 0 |
| `--translate-tags p,h1,h2,h3,figcaption` | 104 → 0 |
| `--plan-classify most` | 244 → 0 |

其他样书（默认标签模式）：`jlreq-in-english` 62 → 0、`figure-gallery-bindings` 56 → 1（这 1 条源书自带）、`trees` 15 → 1、`wasteland` 12 → 1、`moby-dick` 6 → 1、`linear-algebra` 5 → 0、`internallinks` 0 → 0。

剩下没清零的那些与上述三个成因无关：OPF-014 manifest properties、OPF-028 未声明的 metadata 前缀、RSC-010 资源类型、以及 `content.opf` 内部的重复 id——它们来自 metadata/manifest 的重写，本 PR 不处理。

## 测试

`tests/test_epub_output_validity.py`：覆盖上述三个缺陷，同时覆盖规则可能矫枉过正的两种方式——`--single_translate` 必须保留原文自己的 id；普通段落仍然要得到译文兄弟节点。16 个测试里有 12 个在没有本改动时失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
