### PR TITLE
fix(epub): deterministic book identity, working NCX links, stacked bilingual entries, nonzero exit on failure

### DIFF
--- a/.github/workflows/make_test_ebook.yaml
+++ b/.github/workflows/make_test_ebook.yaml
@@ -42,18 +42,24 @@ jobs:
         run: |
             pip install .
 
+      # The free Google endpoint rate-limits back-to-back runs from CI
+      # runners. A failed run now exits nonzero instead of masking the
+      # failure, so the known-transient refusals need a real retry here.
       - name: make normal ebook test using google translate and cli
         run: |
-            bbook_maker --book_name "test_books/Liber_Esther.epub" --test --test_num 10 --model google --translate-tags div,p
-            bbook_maker --book_name "test_books/Liber_Esther.epub" --test --test_num 20 --model google
+            retry() { n=0; until "$@"; do n=$((n+1)); [ "$n" -ge 3 ] && return 1; echo "attempt $n failed; retrying in $((n*30))s"; sleep $((n*30)); done; }
+            retry bbook_maker --book_name "test_books/Liber_Esther.epub" --test --test_num 10 --model google --translate-tags div,p
+            retry bbook_maker --book_name "test_books/Liber_Esther.epub" --test --test_num 20 --model google
 
       - name: make txt book test using google translate
         run: |
-          python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --test_num 20 --model google
+          retry() { n=0; until "$@"; do n=$((n+1)); [ "$n" -ge 3 ] && return 1; echo "attempt $n failed; retrying in $((n*30))s"; sleep $((n*30)); done; }
+          retry python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --test_num 20 --model google
 
       - name: make txt book test with batch_size
         run: |
-          python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --batch_size 30 --test_num 20 --model google
+          retry() { n=0; until "$@"; do n=$((n+1)); [ "$n" -ge 3 ] && return 1; echo "attempt $n failed; retrying in $((n*30))s"; sleep $((n*30)); done; }
+          retry python3 make_book.py --book_name "test_books/the_little_prince.txt" --test --batch_size 30 --test_num 20 --model google
   
       - name: make caiyun translator test
         if: env.BBM_CAIYUN_API_KEY != null

--- a/book_maker/loader/epub_loader.py
+++ b/book_maker/loader/epub_loader.py
@@ -30,6 +30,8 @@ from .base_loader import BaseBookLoader
 from .helper import (
     EPUBBookLoaderHelper,
     append_inline_translation,
+    backfill_toc_hrefs,
+    derive_translation_identity,
     has_restricted_content_model,
     is_text_link,
     not_trans,
@@ -108,6 +110,7 @@ class EPUBBookLoader(BaseBookLoader):
         parallel_workers=1,
     ):
         self.epub_name = epub_name
+        self.language = language
         self.new_epub = epub.EpubBook()
         self.translate_model = model(
             key,
@@ -239,6 +242,15 @@ class EPUBBookLoader(BaseBookLoader):
         # ebooklib's generated navigation document.
         new_book.title = book.title
         new_book.language = book.language
+        # Identity is derived from the *source* book even when rebuilding
+        # from an earlier output (--retranslate), so the same source,
+        # language and mode always name the same translated book.
+        identifier_id = derive_translation_identity(
+            new_book,
+            self.origin_book,
+            self.language,
+            "single" if self.single_translate else "bilingual",
+        )
         allowed_ns = set(epub.NAMESPACES.keys()) | set(epub.NAMESPACES.values())
 
         for namespace, metas in book.metadata.items():
@@ -283,6 +295,16 @@ class EPUBBookLoader(BaseBookLoader):
                     # pointer; keeping it loses the book.
                     continue
 
+                if (
+                    identifier_id
+                    and name == "identifier"
+                    and (others or {}).get("id") == identifier_id
+                ):
+                    # the derived identity above owns this id attribute
+                    # (RSC-005 otherwise); the source's value stays, as a
+                    # secondary identifier without it
+                    others = {k: v for k, v in others.items() if k != "id"}
+
                 # `others` can be {} or None
                 if others:
                     new_book.add_metadata(namespace, name, value, others)
@@ -290,7 +312,7 @@ class EPUBBookLoader(BaseBookLoader):
                     new_book.add_metadata(namespace, name, value)
 
         new_book.spine = book.spine
-        new_book.toc = self._fix_toc_uids(book.toc)
+        new_book.toc = backfill_toc_hrefs(self._fix_toc_uids(book.toc))
         return new_book
 
     def _fix_toc_uids(self, toc, counter=None):
@@ -2179,7 +2201,9 @@ class EPUBBookLoader(BaseBookLoader):
                 print("Saving progress...")
                 self._save_progress()
                 self._save_temp_book()
-            sys.exit(0)
+            # the run failed and there is no output book; exiting 0 would
+            # tell every caller the opposite
+            sys.exit(1)
 
     def load_state(self):
         try:

--- a/book_maker/loader/helper.py
+++ b/book_maker/loader/helper.py
@@ -131,14 +131,22 @@ def append_inline_translation(element, text, translation_style=""):
     document allows one heading before its <ol> and nothing but <a>/<span>
     inside an <li>; a <figure> allows one <figcaption>. Appending a
     translated sibling there produces a book epubcheck rejects, so the
-    translation joins the element's own content instead — a table-of-
-    contents entry reads "Chapter 1 第一章" and stays valid.
+    translation joins the element's own content instead, on its own line —
+    a table-of-contents entry reads "Chapter 1" over "第一章" and stays
+    valid. A <br/> rather than a space, because running two languages
+    together on one line is exactly the crowding the bilingual sibling
+    layout avoids everywhere else.
     """
     span = Tag(name="span")
     if translation_style:
         span["style"] = translation_style
-    span.string = f" {text}"
-    translation_host(element).append(span)
+    span.string = text
+    host = translation_host(element)
+    # can_be_empty_element makes bs4 serialize the void form <br/>; a bare
+    # Tag("br") comes out as the pair <br></br>, which an HTML5 parser
+    # reads as two line breaks.
+    host.append(Tag(name="br", can_be_empty_element=True))
+    host.append(span)
     return span
 
 

--- a/book_maker/loader/helper.py
+++ b/book_maker/loader/helper.py
@@ -1,9 +1,11 @@
 import re
 import backoff
 import logging
+import uuid
 from copy import copy
 
 from bs4.element import Tag
+from ebooklib import epub
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -14,6 +16,72 @@ logger = logging.getLogger(__name__)
 # <figcaption>, and an EPUB 3 navigation document takes one heading before
 # its <ol> and nothing but <a>/<span> inside an <li>.
 SINGLETON_TAGS = frozenset(["figcaption", "caption", "legend", "summary"])
+
+
+def derive_translation_identity(new_book, source_book, *facets):
+    """Give the translated book its own identifier — deterministic, and
+    deliberately not the source's.
+
+    The translation is a different book, so sharing the source identifier
+    would make a library deduplicate one against the other. But ebooklib's
+    default — a fresh uuid on every run — is wrong the other way:
+    regenerate the same translation and every reader sees a brand-new
+    book, duplicating library entries and orphaning reading positions. A
+    UUIDv5 of the source identifier plus the facets that define this
+    translation (target language, bilingual vs single) is stable across
+    runs, distinct from the source, and distinct between facet
+    combinations.
+
+    The seed only has to be stable for the same source file, not
+    semantically primary: ebooklib's reader lets the *last* identified
+    `<dc:identifier>` win `uid`, so adopting it as the book's identity
+    would corrupt `unique-identifier` on multi-identifier sources —
+    deriving from it cannot.
+
+    Returns the `id` attribute now spoken for, so the metadata copy can
+    drop the colliding attribute from the source's own entry; None when
+    the source has no identifier — there is nothing stable to derive
+    from, so ebooklib's per-run uuid stands.
+    """
+    uid = getattr(source_book, "uid", None)
+    if not uid:
+        return None
+    seed = "|".join(["bbook-maker", str(uid), *[str(f) for f in facets]])
+    new_book.set_identifier(str(uuid.uuid5(uuid.NAMESPACE_URL, seed)))
+    return new_book.IDENTIFIER_ID
+
+
+def backfill_toc_hrefs(toc):
+    """Give every `Section` an href, using its first descendant that has one.
+
+    ebooklib's NCX writer says "CAN NOT HAVE EMPTY SRC HERE" and then writes
+    `<content src=""/>` anyway for an hrefless `Section` — which is what a
+    nav `<li>` labelled by a `<span>` rather than an `<a>` becomes
+    (RSC-010): a table-of-contents entry that navigates nowhere on readers
+    using the NCX. An NCX `content` must point somewhere, and the only
+    honest target for a grouping entry is where the group starts.
+    """
+
+    def first_href(node):
+        if isinstance(node, (tuple, list)):
+            for child in node:
+                found = first_href(child)
+                if found:
+                    return found
+            return None
+        if isinstance(node, epub.EpubHtml):
+            return node.file_name
+        return getattr(node, "href", None) or None
+
+    for item in toc:
+        if not isinstance(item, (tuple, list)):
+            continue
+        section, children = item[0], item[1]
+        backfill_toc_hrefs(children)
+        if isinstance(section, epub.Section) and not section.href:
+            section.href = first_href(children) or ""
+
+    return toc
 
 
 def strip_duplicate_ids(element):

--- a/tests/test_epub_loader_correctness.py
+++ b/tests/test_epub_loader_correctness.py
@@ -451,10 +451,6 @@ def test_epub_sequential_batch_excludes_inline_code_content(tmp_path, monkeypatc
     assert loader.translate_model.calls == ["before  after"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="sequential translation errors currently terminate with a success exit code",
-)
 def test_epub_sequential_translation_failure_exits_nonzero(tmp_path, monkeypatch):
     loader, _ = _make_loader(
         tmp_path,
@@ -684,3 +680,25 @@ def test_epub_parallel_honors_block_size(tmp_path, monkeypatch):
         ["three", "four"],
     ]
     assert sorted(loader.translate_model.calls) == ["four", "one", "three", "two"]
+
+
+def test_a_failed_final_write_exits_nonzero(tmp_path, monkeypatch):
+    """A run whose output cannot be written has failed; exiting 0 tells
+    every caller the opposite, with no artifact to contradict it."""
+    loader, output = _make_loader(
+        tmp_path, monkeypatch, [("chapter.xhtml", ["Chapter body"])]
+    )
+    writes = []
+
+    def failing_write(name, book, options=None):
+        writes.append(name)
+        raise OSError("synthetic write failure")
+
+    monkeypatch.setattr("book_maker.loader.epub_loader.epub.write_epub", failing_write)
+
+    with pytest.raises(SystemExit) as excinfo:
+        loader.make_bilingual_book()
+
+    assert writes, "the failure must come from the final write, not earlier"
+    assert excinfo.value.code == 1
+    assert not output.exists()

--- a/tests/test_epub_metadata.py
+++ b/tests/test_epub_metadata.py
@@ -21,6 +21,9 @@ def test_epub_loader_handles_custom_metadata(tmp_path):
         epub.write_epub(str(tmp_path / "legacy.epub"), legacy_book)
 
     loader = EPUBBookLoader.__new__(EPUBBookLoader)
+    loader.origin_book = source_book
+    loader.language = "zh-hans"
+    loader.single_translate = False
     rebuilt_book = loader._make_new_book(source_book)
 
     output_path = tmp_path / "rebuilt.epub"

--- a/tests/test_epub_output_validity.py
+++ b/tests/test_epub_output_validity.py
@@ -128,7 +128,10 @@ def test_nav_link_translation_goes_inside_the_link():
 
     li = soup.find("li")
     assert len(li.find_all("a")) == 1
-    assert li.get_text().split() == ["Chapter", "One", "第一章"]
+    # the translation sits on its own line inside the link, not run into
+    # the original's text
+    assert li.find("a").find("br") is not None
+    assert li.get_text(separator=" ").split() == ["Chapter", "One", "第一章"]
 
 
 def test_nav_list_item_translation_goes_inside_its_link_not_after_the_sublist():
@@ -147,8 +150,10 @@ def test_nav_list_item_translation_goes_inside_its_link_not_after_the_sublist():
     outer = soup.find("li")
     _helper().insert_trans(outer.find("a", recursive=False), "前言")
 
-    # the translation is inside the entry's own link …
-    assert outer.find("a", recursive=False).get_text() == "Preface 前言"
+    # the translation is inside the entry's own link, on its own line …
+    link = outer.find("a", recursive=False)
+    assert link.find("br") is not None
+    assert link.get_text(separator=" ") == "Preface 前言"
     # … and the <li>'s direct children are still exactly (a, ol)
     assert [c.name for c in outer.find_all(recursive=False)] == ["a", "ol"]
 
@@ -166,7 +171,7 @@ def test_nav_list_item_owner_targets_its_link():
     _helper().insert_trans(outer, "前言")
 
     assert [c.name for c in outer.find_all(recursive=False)] == ["a", "ol"]
-    assert outer.find("a", recursive=False).get_text() == "Preface 前言"
+    assert outer.find("a", recursive=False).get_text(separator=" ") == "Preface 前言"
 
 
 def test_nav_heading_keeps_its_translation_inside():

--- a/tests/test_epub_output_validity.py
+++ b/tests/test_epub_output_validity.py
@@ -6,6 +6,7 @@ docstrings so a failure points straight at what a reading system would
 reject.
 """
 
+import uuid
 import zipfile
 from copy import copy
 
@@ -13,7 +14,12 @@ from bs4 import BeautifulSoup as bs
 from ebooklib import epub
 
 from book_maker.loader.epub_loader import EPUBBookLoader
-from book_maker.loader.helper import EPUBBookLoaderHelper, strip_duplicate_ids
+from book_maker.loader.helper import (
+    EPUBBookLoaderHelper,
+    backfill_toc_hrefs,
+    derive_translation_identity,
+    strip_duplicate_ids,
+)
 
 
 def _helper():
@@ -22,6 +28,15 @@ def _helper():
 
 def _soup(html):
     return bs(html, "html.parser")
+
+
+def _rebuilder(source, language="zh-hans", single=False):
+    """A loader with only what `_make_new_book` touches."""
+    loader = EPUBBookLoader.__new__(EPUBBookLoader)
+    loader.origin_book = source
+    loader.language = language
+    loader.single_translate = single
+    return loader
 
 
 def _loader():
@@ -221,7 +236,7 @@ def test_new_book_gets_an_ncx_when_the_source_has_none(tmp_path):
     source.set_title("No NCX Here")
     source.set_language("en")
 
-    rebuilt = EPUBBookLoader.__new__(EPUBBookLoader)._make_new_book(source)
+    rebuilt = _rebuilder(source)._make_new_book(source)
 
     assert [i for i in rebuilt.get_items() if isinstance(i, epub.EpubNcx)]
 
@@ -232,7 +247,7 @@ def test_new_book_does_not_add_a_second_ncx(tmp_path):
     source.set_language("en")
     source.add_item(epub.EpubNcx())
 
-    rebuilt = EPUBBookLoader.__new__(EPUBBookLoader)._make_new_book(source)
+    rebuilt = _rebuilder(source)._make_new_book(source)
 
     assert len([i for i in rebuilt.get_items() if isinstance(i, epub.EpubNcx)]) <= 1
 
@@ -258,7 +273,7 @@ def test_link_metadata_is_dropped_rather_than_written_as_meta(tmp_path):
         },
     )
 
-    rebuilt = EPUBBookLoader.__new__(EPUBBookLoader)._make_new_book(source)
+    rebuilt = _rebuilder(source)._make_new_book(source)
 
     for namespace, entries in rebuilt.metadata.items():
         assert "link" not in entries, f"link metadata survived in {namespace!r}"
@@ -269,3 +284,113 @@ def test_link_metadata_is_dropped_rather_than_written_as_meta(tmp_path):
         opf = next(n for n in book.namelist() if n.endswith(".opf"))
         content = book.read(opf).decode("utf-8")
     assert 'rel="dcterms:conformsTo"' not in content
+
+
+# ------------------------------------------------------- the book's identity
+
+
+def _opf_of(path):
+    with zipfile.ZipFile(path) as archive:
+        name = next(n for n in archive.namelist() if n.endswith(".opf"))
+        return archive.read(name).decode("utf-8")
+
+
+def _identified_source(uid="http://www.gutenberg.org/ebooks/25545"):
+    source = epub.EpubBook()
+    source.set_identifier(uid)
+    source.set_title("Identified")
+    source.set_language("en")
+    return source
+
+
+def test_translation_identity_is_deterministic_and_distinct():
+    """Rebuilding the same translation must name the same book — ebooklib's
+    per-run uuid makes every rerun a new library entry — but it must not be
+    the source's identifier either, or a reader deduplicates the
+    translation against the original."""
+    source = _identified_source()
+
+    first = _rebuilder(source)._make_new_book(source)
+    second = _rebuilder(source)._make_new_book(source)
+
+    assert first.uid == second.uid
+    assert first.uid != source.uid
+    uuid.UUID(first.uid)  # a well-formed uuid, not a concatenation
+
+
+def test_translation_identity_varies_with_language_and_mode():
+    """zh and ja translations of one source are different books, and so are
+    the bilingual and single renderings."""
+    source = _identified_source()
+
+    zh = _rebuilder(source, "zh-hans")._make_new_book(source).uid
+    ja = _rebuilder(source, "ja")._make_new_book(source).uid
+    single = _rebuilder(source, "zh-hans", single=True)._make_new_book(source).uid
+
+    assert len({zh, ja, single}) == 3
+
+
+def test_source_identifier_is_kept_without_a_colliding_id(tmp_path):
+    """RSC-005 'Duplicate "id"': the derived identity is written under
+    ebooklib's id="id"; a source identifier that also carries id="id" must
+    lose the attribute, not the value."""
+    source = _identified_source()
+    rebuilt = _rebuilder(source)._make_new_book(source)
+
+    out = tmp_path / "identified.epub"
+    epub.write_epub(str(out), rebuilt)
+    opf = _opf_of(out)
+
+    assert opf.count('id="id"') == 1, "two elements answer to the same id"
+    assert rebuilt.uid in opf
+    assert "http://www.gutenberg.org/ebooks/25545" in opf
+
+
+def test_an_identifierless_source_derives_nothing():
+    """No identifier means nothing stable to derive from; the helper must
+    say so instead of minting an identity out of thin air."""
+    new_book = epub.EpubBook()
+    before = new_book.uid
+
+    class Bare:
+        uid = None
+
+    assert derive_translation_identity(new_book, Bare(), "zh-hans") is None
+    assert new_book.uid == before  # untouched
+
+
+# ------------------------------------------------------------------ the NCX
+
+
+def test_a_section_without_an_href_is_given_one():
+    """RSC-010: ebooklib writes <content src=""/> for an hrefless Section —
+    a TOC entry that navigates nowhere on NCX-reading systems."""
+    toc = [
+        (
+            epub.Section("Part One"),
+            [epub.Link("ch01.xhtml", "One", "ch01")],
+        )
+    ]
+
+    backfill_toc_hrefs(toc)
+
+    assert toc[0][0].href == "ch01.xhtml"
+
+
+def test_nested_sections_are_backfilled_from_their_own_subtree():
+    inner = (epub.Section("Inner"), [epub.Link("ch02.xhtml", "Two", "ch02")])
+    outer = (epub.Section("Outer"), [inner])
+
+    backfill_toc_hrefs([outer])
+
+    assert inner[0].href == "ch02.xhtml"
+    assert outer[0].href == "ch02.xhtml"
+
+
+def test_a_section_with_an_href_keeps_it():
+    section = epub.Section("Named", href="intro.xhtml")
+    toc = [(section, [epub.Link("ch01.xhtml", "One", "ch01")])]
+
+    backfill_toc_hrefs(toc)
+
+    assert section.href == "intro.xhtml"


### PR DESCRIPTION
## Summary

Three small fixes to what the written book is like for a reader, none touching translation:

- **A deterministic identity for the translated book.** ebooklib mints a fresh UUID on every run, so regenerating the same translation gives every library app a "new" book — duplicate entries, orphaned reading positions. Adopting the source identifier verbatim is wrong the other way: a reader would deduplicate the translation against the original. The identifier is now a UUIDv5 derived from source identifier + target language + bilingual/single mode: stable across reruns, distinct from the source, distinct per language and mode. The source identifier stays as a secondary `dc:identifier` (its colliding `id` attribute stripped, which also removes a duplicate-id error).
- **In-element translations sit on their own line.** Where a translated sibling is invalid (nav entries, `figcaption`, …) the translation goes inside the element — previously run into the original with a space, now separated by `<br/>` so a TOC entry reads as two stacked lines, like bilingual output everywhere else. Serialized in void form (`<br></br>` would double the break in HTML5 parsers).
- **Fail loud.** A TOC section without an href no longer becomes an NCX entry with `src=""` (a link that navigates nowhere on NCX-reading systems) — it's backfilled from its first descendant. And a run that dies now exits 1 instead of 0; there is no output book, so reporting success taught every calling script the opposite.

## Why

Rerunning a translation shouldn't multiply books in the reader's library, a TOC entry shouldn't go nowhere, a bilingual TOC entry shouldn't read as one crowded line, and a failed run shouldn't say it succeeded. All four are behaviors of the current writer path, reproduced on the IDPF `epub3-samples`.

Deriving rather than adopting the identity also sidesteps an ebooklib reader defect: with multiple identified `dc:identifier` elements the *last* one wins `uid`, so verbatim adoption could rewrite `unique-identifier` to a secondary identifier. A derived id only needs the seed to be stable, not semantically primary.

## Impact

Output and exit code only; no change to translation behavior or CLI flags. `--retranslate` seeds identity from the source book, so a fixed-up book keeps the same identifier as the run it fixes.

## Verification

- `childrens-literature.epub` round-trip: the duplicate-identifier errors (RSC-005 ×2) and the empty-src error (RSC-010) are gone; two consecutive runs produce the identical identifier (`abe55268-a563-5c82-…`), with the Gutenberg identifier kept as secondary.
- A nav document with `<br/>` inside its `<a>` labels and heading passes epubcheck 5.3.0.
- The pre-existing strict-xfail test for the exit-0 defect (`test_epub_sequential_translation_failure_exits_nonzero`) now passes and its marker is removed; a new regression covers a failed final write (nonzero exit, no artifact).
- Full non-network suite: 423 passed, Black clean; the single failure (`test_pdf_layouts`) is pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
