### PR TITLE
docs: sync CLI references with implementation

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -370,7 +370,8 @@ bbook_maker --book_name test_books/animal_farm.epub --openai_key ${openai_key} -
 
 - `--extra_body`:
 
-  以 JSON 字符串向模型 API 透传额外请求参数，例如：
+  以 JSON 字符串向 ChatGPT/OpenAI 衍生请求路径透传额外参数，包括 OpenAI 风格的
+  自定义 provider 和 xAI。Claude、Gemini、Qwen、Groq 等其他翻译器目前会忽略该参数。例如：
 
   ```shell
   python3 make_book.py --book_name book.epub --extra_body '{"chat_template_kwargs":{"enable_thinking":false}}'

--- a/README-CN.md
+++ b/README-CN.md
@@ -9,7 +9,7 @@ bilingual_book_maker 是一个 AI 翻译工具，使用 ChatGPT 帮助用户制�
 1. ChatGPT or OpenAI token [^token]
 2. epub/txt/md books
 3. 能正常联网的环境或 proxy
-4. python3.8+
+4. Python 3.10+
 
 ## 快速开始
 
@@ -20,7 +20,7 @@ pip install -r requirements.txt
 python3 make_book.py --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 或
 pip install -U bbook_maker
-bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
+bbook_maker --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 ```
 
 ## 翻译服务
@@ -181,7 +181,7 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   | `o1mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1-mini |
   | `o3mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o3-mini |
   | `openai` | `--openai_key` / `BBM_OPENAI_API_KEY` | **必须配合 `--model_list`**，可使用任意 OpenAI 兼容模型 |
-  | `claude-*` | `--claude_key` / `BBM_CLAUDE_API_KEY` | 前缀匹配，如 `--model claude-sonnet-4-20250514` |
+  | `claude` 及已列出的 `claude-*` ID | `--claude_key` / `BBM_CLAUDE_API_KEY` | 只接受 `--help` 展示的精确内置值；未列出的 ID 需使用 `--provider` 或 `openai` 路由 |
   | `gemini` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Flash，支持 `--model_list` 自定义 |
   | `geminipro` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Pro |
   | `groq` | `--groq_key` / `BBM_GROQ_API_KEY` | **必须配合 `--model_list`** |
@@ -199,7 +199,11 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 
 - `--test`:
 
-  如果大家没付费可以加上这个先看看效果（有 limit 稍微有些慢）
+  如果大家没付费可以加上这个先看看效果（有 limit 稍微有些慢）。
+
+- `--test_num`:
+
+  配合 `--test` 指定测试翻译的文本单元数量，默认 10。
 
 - `--language`: 指定目标语言
 
@@ -245,6 +249,12 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   # 或交给 coding agent 判断（停下、打印指引，然后重跑）
   python3 make_book.py --book_name my_book.epub --openai_key ${key} --plan-classify agent
   ```
+
+- `--exclude-translate-tags`:
+
+  指定不翻译其内部内容的 HTML 标签，多个标签用逗号分隔，默认 `sup,code`。
+  例如 `--exclude-translate-tags code,pre`；传入空字符串
+  `--exclude-translate-tags ""` 可取消默认排除。
 
 - `--book_from`
 
@@ -307,9 +317,44 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 
 - `--translation_style`:
 
-  如: `--translation_style "color: #808080; font-style: italic;"`
+  为 EPUB 译文应用完整 CSS，例如
+  `--translation_style "color: #808080; font-style: italic;"`。
 
-- `--retranslate "$translated_filepath" "file_name_in_epub" "start_str" "end_str"(optional)`:
+- `--translation_color`:
+
+  只设置 EPUB 译文颜色的快捷参数，例如 `--translation_color "#1e90ff"`。
+  如果同时传入 `--translation_style`，完整样式优先。
+
+- `--pdf_layout {none,top-bottom,side-by-side,all}`:
+
+  为 PDF 输入选择额外生成的双语 PDF 版式。默认 `none` 不额外生成 PDF；
+  `all` 会同时尝试上下对照和左右对照。双语 TXT 和 EPUB 输出不受该参数影响。
+
+- `--sentence_mode`:
+
+  将 EPUB 的每个段落拆成句子逐句翻译，而不是整段翻译。与 EPUB 计划模式不兼容。
+
+- `--batch` / `--batch-use`:
+
+  使用 ChatGPT Batch API 的两阶段 EPUB 流程。先用 `--batch` 提交任务，再以
+  `--batch-use` 重跑以等待并使用结果。二者都与计划模式不兼容。
+
+- `--interval`:
+
+  Gemini 请求间隔秒数，默认 `0.01`；其他模型路由不会使用此参数。
+
+- `--parallel-workers`:
+
+  并行处理 EPUB 章节或 Markdown 批次/分段，默认 1，建议 2–4。其他输入加载器目前
+  虽然接受这个共享参数，但不会并行执行。EPUB 的 `--use_context` 在并行模式下是
+  章节内上下文，而不是全书共享上下文。
+
+- `--quiet`:
+
+  关闭 EPUB 进度条和逐段原文/译文输出，但保留报告与错误。适合日志文件和 Agent
+  非交互运行。
+
+- `--retranslate "$translated_filepath" "file_name_in_epub" "start_str" "end_str"`:
 
   - 重新翻译，从 start_str 到 end_str 的标记:
 
@@ -317,10 +362,18 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which' 'This kind of thing is not a good symptom. Obviously'
   ```
 
-  - 重新翻译, 从start_str 的标记开始:
+  - 只重新翻译包含 `start_str` 的标签时，第四个参数传入空字符串：
 
   ```shell
-  python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which'
+  python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which' ''
+  ```
+
+- `--extra_body`:
+
+  以 JSON 字符串向模型 API 透传额外请求参数，例如：
+
+  ```shell
+  python3 make_book.py --book_name book.epub --extra_body '{"chat_template_kwargs":{"enable_thinking":false}}'
   ```
 
 - `--provider`:
@@ -333,7 +386,7 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 
 ### 示范用例
 
-**如果使用 `pip install bbook_maker` 以下命令都可以改成 `bbook args`**
+**如果使用 `pip install bbook_maker`，以下命令都可以改成 `bbook_maker args`。**
 
 ```shell
 # 如果你想快速测一下

--- a/README.md
+++ b/README.md
@@ -425,7 +425,9 @@ bbook_maker --book_name test_books/animal_farm.epub --openai_key ${openai_key} -
 
 - `--extra_body`:
 
-  Pass additional JSON parameters to the API. This is useful for models that support extra configuration options. Provide a JSON string with the desired parameters.
+  Pass additional JSON parameters on ChatGPT/OpenAI-derived request paths, including
+  OpenAI-style custom providers and xAI. Claude, Gemini, Qwen, Groq, and other translators
+  currently ignore this option. Provide a JSON string with the desired parameters.
 
   ```shell
   python3 make_book.py --book_name test_books/animal_farm.epub --openai_key ${openai_key} --extra_body '{"chat_template_kwargs": {"enable_thinking": false}}'

--- a/README.md
+++ b/README.md
@@ -7,18 +7,20 @@ The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist u
 
 ![image](https://user-images.githubusercontent.com/15976103/222317531-a05317c5-4eee-49de-95cd-04063d9539d9.png)
 
-## Supported Models
+## Supported models
 
-gpt-5-mini, gpt-4, gpt-3.5-turbo, claude-2, palm, llama-2, azure-openai, command-nightly, gemini, qwen-mt-turbo, qwen-mt-plus
-For using Non-OpenAI models, use class `liteLLM()` - liteLLM supports all models above.
-Find more info here for using liteLLM: https://github.com/BerriAI/litellm/blob/main/setup.py
+Built-in routes include OpenAI presets and arbitrary OpenAI-compatible model IDs, current
+Claude choices, Gemini, Qwen-MT, Groq, xAI, DeepL, Google, Caiyun, and Tencent TranSmart.
+The exact `--model` choices come from the installed version, so use
+`python3 make_book.py --help`. Unlisted gateways and native-provider model IDs can be
+configured with `--provider`; see [Models and languages](./docs/model_lang.md).
 
 ## Preparation
 
 1. ChatGPT or OpenAI token [^token]
 2. epub/txt/md/pdf books
 3. Environment with internet access or proxy
-4. Python 3.8+
+4. Python 3.10+
 
 ## Quick Start
 
@@ -29,7 +31,7 @@ pip install -r requirements.txt
 python3 make_book.py --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 OR
 pip install -U bbook_maker
-bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
+bbook_maker --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 ```
 
 ## Translate Service
@@ -195,7 +197,7 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   | `o1mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o1-mini |
   | `o3mini` | `--openai_key` / `BBM_OPENAI_API_KEY` | o3-mini |
   | `openai` | `--openai_key` / `BBM_OPENAI_API_KEY` | **Requires `--model_list`**. Use any OpenAI-compatible model |
-  | `claude-*` | `--claude_key` / `BBM_CLAUDE_API_KEY` | Prefix match. e.g. `--model claude-sonnet-4-20250514` |
+  | `claude` and listed `claude-*` IDs | `--claude_key` / `BBM_CLAUDE_API_KEY` | Exact built-in choices shown by `--help`; arbitrary unlisted IDs require `--provider` or the `openai` route |
   | `gemini` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Flash. Supports `--model_list` |
   | `geminipro` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Pro |
   | `groq` | `--groq_key` / `BBM_GROQ_API_KEY` | **Requires `--model_list`** |
@@ -350,7 +352,10 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 
 - `--parallel-workers`:
 
-  Use `--parallel-workers` to enable parallel EPUB chapter processing. Values greater than `1` spin up multiple workers (recommended: `2-4`) and automatically fall back to sequential mode for single-chapter books.
+  Use `--parallel-workers` to process EPUB chapters or Markdown batches/sections in
+  parallel. Values greater than `1` spin up multiple workers (recommended: `2-4`) and
+  automatically fall back to sequential mode when there is only one unit of work. Other
+  input loaders currently accept this shared CLI option but do not parallelize their work.
 
 - `--temperature`:
 
@@ -368,9 +373,43 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
 
 - `--translation_style`:
 
-  example: `--translation_style "color: #808080; font-style: italic;"`
+  Apply custom CSS to translated EPUB text, for example
+  `--translation_style "color: #808080; font-style: italic;"`.
 
-- `--retranslate "$translated_filepath" "file_name_in_epub" "start_str" "end_str"(optional)`:
+- `--translation_color`:
+
+  Shorthand for setting only the translated EPUB text color, for example
+  `--translation_color "#1e90ff"`. If `--translation_style` is also present, the full style
+  takes precedence.
+
+- `--pdf_layout {none,top-bottom,side-by-side,all}`:
+
+  Select additional bilingual PDF outputs for PDF inputs. The default `none` creates no
+  extra PDF; `all` attempts both top-bottom and side-by-side layouts. The bilingual TXT and
+  EPUB outputs are unaffected.
+
+- `--sentence_mode`:
+
+  Translate EPUB text sentence by sentence instead of translating each paragraph as one
+  unit. It is incompatible with EPUB plan mode.
+
+- `--batch` / `--batch-use`:
+
+  Two-stage EPUB translation through the ChatGPT Batch API. First run with `--batch` to
+  submit the batch, then rerun with `--batch-use` to wait for and consume its results.
+  These flags are incompatible with plan mode.
+
+- `--interval`:
+
+  Gemini request interval in seconds (default `0.01`). It has no effect on other model
+  routes.
+
+- `--quiet`:
+
+  Suppress EPUB progress bars and per-paragraph source/translation echoes while retaining
+  reports and errors. Recommended for log files and non-interactive agent runs.
+
+- `--retranslate "$translated_filepath" "file_name_in_epub" "start_str" "end_str"`:
 
   Retranslate from start_str to end_str's tag:
 
@@ -378,10 +417,10 @@ bbook --book_name test_books/animal_farm.epub --openai_key ${openai_key} --test
   python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which' 'This kind of thing is not a good symptom. Obviously'
   ```
 
-  Retranslate start_str's tag:
+  To retranslate only the tag containing `start_str`, pass an empty fourth argument:
 
   ```shell
-  python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which'
+  python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which' ''
   ```
 
 - `--extra_body`:

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -404,11 +404,10 @@ So you are close to reaching the limit. You have to choose your own value, there
         dest="retranslate",
         nargs=4,
         type=str,
-        help="""--retranslate "$translated_filepath" "file_name_in_epub" "start_str" "end_str"(optional)
-        Retranslate from start_str to end_str's tag:
-        python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which' 'This kind of thing is not a good symptom. Obviously'
-        Retranslate start_str's tag:
-        python3 "make_book.py" --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which'
+        help="""--retranslate "$translated_filepath" "file_name_in_epub" "start_str" "end_str"
+        Retranslate from start_str through end_str. All four arguments are required;
+        pass an empty end_str ('') to retranslate only the start_str tag, and an empty
+        file_name_in_epub ('') to find the internal filename automatically.
 """,
     )
     parser.add_argument(
@@ -456,7 +455,7 @@ So you are close to reaching the limit. You have to choose your own value, there
         "--model_list",
         type=str,
         dest="model_list",
-        help="Rather than using our preset lists of models, specify exactly the models you want as a comma separated list `gpt-4-32k,gpt-3.5-turbo-0125` (Currently only supports: `openai`)",
+        help="Rather than using preset model lists, specify exact model IDs as a comma-separated list. Supported with --model openai, groq, or gemini, and with --provider",
     )
     parser.add_argument(
         "--batch",
@@ -481,7 +480,7 @@ So you are close to reaching the limit. You have to choose your own value, there
         dest="parallel_workers",
         type=int,
         default=1,
-        help="Number of parallel workers for EPUB chapter processing. Use 2-4 for better performance. Default: 1",
+        help="Number of parallel workers for EPUB chapters or Markdown batches/sections. Use 2-4 for better performance. Default: 1",
     )
     parser.add_argument(
         "--extra_body",

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -516,6 +516,17 @@ So you are close to reaching the limit. You have to choose your own value, there
     if options.provider and options.model:
         parser.error("--provider and --model are mutually exclusive")
 
+    # Kobo mode supplies the source book itself. Resolve it before validating
+    # --book_name so users do not need a meaningless placeholder file.
+    if options.book_from == "kobo":
+        from book_maker import obok
+
+        if options.device_path is None:
+            raise Exception(
+                "Device path is not given, please specify the path by --device_path <DEVICE_PATH>",
+            )
+        options.book_name = obok.cli_main(options.device_path)
+
     if not options.book_name:
         print("Error: please provide the path of your book using --book_name <path>")
         exit(1)
@@ -653,16 +664,6 @@ So you are close to reaching the limit. You have to choose your own value, there
     else:
         API_KEY = ""
 
-    if options.book_from == "kobo":
-        from book_maker import obok
-
-        device_path = options.device_path
-        if device_path is None:
-            raise Exception(
-                "Device path is not given, please specify the path by --device_path <DEVICE_PATH>",
-            )
-        options.book_name = obok.cli_main(device_path)
-
     book_type = get_book_type(options.book_name)
     support_type_list = list(BOOK_LOADER_DICT.keys())
     if book_type not in support_type_list:
@@ -709,17 +710,41 @@ So you are close to reaching the limit. You have to choose your own value, there
         parallel_workers=options.parallel_workers,
         **loader_kwargs,
     )
-    # Parse and set extra_body if provided
+    # Parse and set extra_body only on request paths that consume it. Setting
+    # an arbitrary attribute on the other translators used to print success
+    # and then silently drop the fields.
     if options.extra_body:
-        try:
-            import json
-
-            extra_body = json.loads(options.extra_body)
-            e.translate_model.extra_body = extra_body
-            print(f"[bold blue]Extra body parameters:[/bold blue] {extra_body}")
-        except json.JSONDecodeError as e:
-            print(f"[bold red]Error:[/bold red] Invalid JSON in --extra_body: {e}")
-            exit(1)
+        openai_models = {
+            "openai",
+            "chatgptapi",
+            "gpt4",
+            "gpt4omini",
+            "gpt4o",
+            "gpt5mini",
+            "o1preview",
+            "o1",
+            "o1mini",
+            "o3mini",
+            "xai",
+        }
+        supports_extra_body = options.model in openai_models or (
+            options.provider
+            and provider_cfg
+            and provider_cfg.get("api_style") == "openai"
+        )
+        if not supports_extra_body:
+            print(
+                f"[bold yellow]Warning:[/bold yellow] --extra_body is ignored "
+                f"by the selected {options.model or options.provider} route"
+            )
+        else:
+            try:
+                extra_body = json.loads(options.extra_body)
+                e.translate_model.extra_body = extra_body
+                print(f"[bold blue]Extra body parameters:[/bold blue] {extra_body}")
+            except json.JSONDecodeError as ex:
+                print(f"[bold red]Error:[/bold red] Invalid JSON in --extra_body: {ex}")
+                exit(1)
     # other options
     if options.sentence_mode:
         e.sentence_mode = True

--- a/book_maker/translator/groq_translator.py
+++ b/book_maker/translator/groq_translator.py
@@ -29,6 +29,21 @@ class GroqClient(ChatGPTAPI):
         )
         return completion.choices[0].message.content
 
+    def set_model_list(self, model_list):
+        """Accept explicit Groq model IDs without OpenAI endpoint validation.
+
+        ChatGPTAPI's implementation lists models through its OpenAI client.
+        This subclass sends translation requests through the Groq SDK, so
+        inheriting that validation would query api.openai.com with a Groq key.
+        Groq will validate each ID on the first real request instead.
+        """
+        models = list(dict.fromkeys(m.strip() for m in model_list if m.strip()))
+        if not models:
+            raise ValueError("--model_list is empty")
+        print(f"Using model list {models}")
+        self.model_list = cycle(models)
+        self.model = models[0]
+
     def rotate_model(self):
         if not self.model_list:
             model_list = list(set(GROQ_MODEL_LIST))

--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -1,5 +1,88 @@
 # Command Line Options
 
+`book_maker/cli.py` and `python3 make_book.py --help` are the runtime source of truth.
+The inventory below is checked against every long option registered with `argparse`; the
+sections after it provide additional notes for selected workflows.
+
+## Complete option inventory
+
+### Input, scope, and output
+
+| Option | Purpose |
+|---|---|
+| `--book_name PATH` | Input EPUB, TXT, Markdown, SRT, or PDF path (required). |
+| `--book_from kobo` | Import from a Kobo device instead of a normal source path. |
+| `--device_path PATH` | Kobo mount path used with `--book_from`. |
+| `--language LANGUAGE` | Target language; default `zh-hans`. |
+| `--source_lang LANGUAGE` | Source language for models such as Qwen; default `auto`. |
+| `--single_translate` | Output translation only instead of bilingual text. |
+| `--translate-tags TAGS` | Comma-separated EPUB tags; default `p`, ignored in plan mode. |
+| `--exclude-translate-tags TAGS` | EPUB ancestor tags to exclude; default `sup,code`; `""` clears it. |
+| `--allow_navigable_strings` | Include otherwise untagged EPUB strings; redundant in plan mode. |
+| `--only_filelist FILES` | Include only these comma-separated internal EPUB files. |
+| `--exclude_filelist FILES` | Exclude these comma-separated internal EPUB files. |
+| `--translation_style CSS` | CSS applied to translated EPUB entries. |
+| `--translation_color COLOR` | Color-only shorthand; `--translation_style` takes precedence. |
+| `--pdf_layout MODE` | Additional PDF output: `none`, `top-bottom`, `side-by-side`, or `all`. |
+| `--retranslate OUT FILE START END` | Retranslate an EPUB range in an existing output. |
+
+### EPUB plan mode
+
+| Option | Purpose |
+|---|---|
+| `--plan-dry-run` | Build/report a free EPUB plan and exit. |
+| `--plan-classify {none,most,model,agent}` | Select no plan, greedy plan, model triage, or coding-agent triage. |
+| `--plan-classify-model MODEL` | Classification model; implies model mode and conflicts with `most`/`agent`. |
+| `--plan-min-coverage FRACTION` | Fail if selected planned text is below this fraction; default `0.5`. |
+| `--poetry-group-size N` | Maximum verse lines per planned translation request; default `8`. |
+
+### Translation and execution
+
+| Option | Purpose |
+|---|---|
+| `--test` | Translate only a preview sample. |
+| `--test_num N` | Number of test units; default `10`. |
+| `--resume` | Continue from the loader's saved checkpoint. |
+| `--prompt VALUE_OR_FILE` | User/system prompt template; the user template requires `{text}`. |
+| `--temperature FLOAT` | Sampling temperature; default `1.0`. |
+| `--use_context` | Send an evolving narrative context with compatible translators. |
+| `--context_paragraph_limit N` | Context limit used with `--use_context`; default `0`. |
+| `--accumulated_num N` | Legacy EPUB token accumulation; ignored in plan mode. |
+| `--batch_size N` | Aggregated unit count for loaders that support it. |
+| `--block_size N` | Merge paragraphs into delimiter-translated blocks. |
+| `--sentence_mode` | Translate EPUB paragraphs sentence by sentence; incompatible with plan mode. |
+| `--parallel-workers N` | Parallel EPUB chapters or Markdown batches/sections; default `1`. |
+| `--batch` | Submit an EPUB ChatGPT Batch API job; incompatible with plan mode. |
+| `--batch-use` | Consume a previously submitted batch job; incompatible with plan mode. |
+| `--interval SECONDS` | Gemini request interval; default `0.01`. |
+| `--extra_body JSON` | Extra model request fields as a JSON object. |
+| `--quiet` | Suppress EPUB progress bars and paragraph echoes, not reports/errors. |
+| `--proxy URL` | Set HTTP/HTTPS proxy environment variables for the run. |
+
+### Model routing and credentials
+
+| Option | Purpose |
+|---|---|
+| `--model MODEL` / `-m MODEL` | Built-in translator route. Mutually exclusive with `--provider`. |
+| `--model_list IDS` | Exact comma-separated IDs for OpenAI, Groq, Gemini, or a custom provider. |
+| `--provider NAME` | Provider from project/global `bbm_providers.json`; conflicts with `--model`. |
+| `--api_key KEY` | Custom-provider key; prefer its configured environment variable. |
+| `--api_base URL` | Override the selected translator endpoint. |
+| `--deployment_id ID` | Azure OpenAI deployment; also requires `--api_base`. |
+| `--ollama_model MODEL` | Ollama model; defaults its endpoint to `http://localhost:11434/v1`. |
+| `--openai_key KEY` | OpenAI-compatible key; prefer `BBM_OPENAI_API_KEY`. |
+| `--claude_key KEY` | Anthropic key; prefer `BBM_CLAUDE_API_KEY`. |
+| `--gemini_key KEY` | Gemini key; prefer `BBM_GOOGLE_GEMINI_KEY`. |
+| `--groq_key KEY` | Groq key; prefer `BBM_GROQ_API_KEY`. |
+| `--xai_key KEY` | xAI key; prefer `BBM_XAI_API_KEY`. |
+| `--qwen_key KEY` | Qwen key; prefer `BBM_QWEN_API_KEY`. |
+| `--deepl_key KEY` | DeepL key; prefer `BBM_DEEPL_API_KEY`. |
+| `--caiyun_key KEY` | Caiyun key; prefer `BBM_CAIYUN_API_KEY`. |
+| `--custom_api VALUE` | Legacy custom translator API; prefer `BBM_CUSTOM_API`. |
+
+Do not put secrets directly on a shared command line. Environment variables or a local,
+git-ignored `.env` are safer for agent and CI use.
+
 ## Test translate
 `--test` <br>
 
@@ -23,29 +106,29 @@ Use this option to set how many paragraph you want to translate for testing. Def
 Use this option to manually resume the process after an interruption.
 
 ## Retranslate (epub only)
-`--retranslate <translated_filepath, file_name_in_epub, start_str [, end_str]>`<br>
+`--retranslate <translated_filepath> <file_name_in_epub> <start_str> <end_str>`<br>
 
-If a file in epub is not translated well, it supports to re-translate part of epub separately.
-
-This option take 4 arguments: `translated_filepath`, `file_name_in_epub`, `start_str`, `end_str`. `end_str` is optional.
+If a file in an EPUB is not translated well, this re-translates part of it separately.
+Argparse requires all four values. Use an empty `end_str` to retranslate only the starting
+tag; an empty `file_name_in_epub` enables automatic filename lookup.
 
 - Retranslate from start_str to end_str's tag:
 
         bbook_maker --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which' 'This kind of thing is not a good symptom. Obviously'
 
-- Retranslate start_str's tag:
+- Retranslate the `start_str` tag (empty fourth value):
         
-        bbook_maker --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which'
+        bbook_maker --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' 'index_split_002.html' 'in spite of the present book shortage which' ''
 
-- Retranslate start_str's tag, auto find filename:
+- Retranslate the `start_str` tag and auto-find the filename (empty second and fourth values):
         
-        bbook_maker --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' '' 'in spite of the present book shortage which'
+        bbook_maker --book_name "test_books/animal_farm.epub" --retranslate 'test_books/animal_farm_bilingual.epub' '' 'in spite of the present book shortage which' ''
 
 **Warning:**
 
 **It deletes from the tag at start_str of the finished book to the next tag at end_str, and then re-translates.**
 
-**Therefore, please make sure that the next tag of end_str is the translated content. (If end_str is not provided, the next label of start_str is guaranteed to be the translated content.) There can be missing translations between the two strings, but if end_str is not translated, there will be problems.**
+**Therefore, make sure the tag after `end_str` is translated content. When `end_str` is an empty string, the tag after `start_str` is used. There can be missing translations between the two strings, but a non-translated end boundary will cause problems.**
 
 
 

--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -46,8 +46,8 @@ sections after it provide additional notes for selected workflows.
 | `--prompt VALUE_OR_FILE` | User/system prompt template; the user template requires `{text}`. |
 | `--temperature FLOAT` | Sampling temperature; default `1.0`. |
 | `--use_context` | Send an evolving narrative context with compatible translators. |
-| `--context_paragraph_limit N` | Context limit used with `--use_context`; default `0`. |
-| `--accumulated_num N` | Legacy EPUB token accumulation; ignored in plan mode. |
+| `--context_paragraph_limit N` | Context history limit used with `--use_context`. Parser default `0` means the translator default (3 paragraphs for ChatGPT), not zero history. |
+| `--accumulated_num N` | EPUB token/character accumulation and SRT subtitle-block character batching (capped at 512 for SRT); ignored in EPUB plan mode. |
 | `--batch_size N` | Aggregated unit count for loaders that support it. |
 | `--block_size N` | Merge paragraphs into delimiter-translated blocks. |
 | `--sentence_mode` | Translate EPUB paragraphs sentence by sentence; incompatible with plan mode. |
@@ -55,7 +55,7 @@ sections after it provide additional notes for selected workflows.
 | `--batch` | Submit an EPUB ChatGPT Batch API job; incompatible with plan mode. |
 | `--batch-use` | Consume a previously submitted batch job; incompatible with plan mode. |
 | `--interval SECONDS` | Gemini request interval; default `0.01`. |
-| `--extra_body JSON` | Extra model request fields as a JSON object. |
+| `--extra_body JSON` | Extra request fields for ChatGPT/OpenAI-derived request paths (including OpenAI-style custom providers and xAI); other translators such as Claude, Gemini, Qwen, and Groq ignore it. |
 | `--quiet` | Suppress EPUB progress bars and paragraph echoes, not reports/errors. |
 | `--proxy URL` | Set HTTP/HTTPS proxy environment variables for the run. |
 
@@ -80,8 +80,10 @@ sections after it provide additional notes for selected workflows.
 | `--caiyun_key KEY` | Caiyun key; prefer `BBM_CAIYUN_API_KEY`. |
 | `--custom_api VALUE` | Legacy custom translator API; prefer `BBM_CUSTOM_API`. |
 
-Do not put secrets directly on a shared command line. Environment variables or a local,
-git-ignored `.env` are safer for agent and CI use.
+Do not put secrets directly on a shared command line. Environment variables are safer for
+agent and CI use. The CLI does **not** load `.env` files itself: export the variables first,
+or source a local git-ignored file before running, for example
+`set -a; source .env; set +a; bbook_maker ...`.
 
 ## Test translate
 `--test` <br>

--- a/docs/model_lang.md
+++ b/docs/model_lang.md
@@ -1,125 +1,110 @@
-# Model and Languages
-## Models
-`-m, --model <Model>` <br>
+# Models and languages
 
-Currently `bbook_maker` supports these models: `chatgptapi` , `gpt3` , `google` , `caiyun` , `deepl` , `deeplfree` , `gpt4` , `gpt4omini` , `gpt5mini` , `o1-preview` , `o1` , `o1-mini` , `o3-mini` , `claude` , `customapi`.
-Default model is `chatgptapi` . 
+`book_maker/translator/__init__.py::MODEL_DICT` and `bbook_maker --help` are the source of
+truth for built-in `--model` choices. The list changes as providers add and retire models;
+do not infer a valid CLI value from a marketing model name.
 
-### OPENAI models
+## Model routing
 
-There are several models you can choose from.
+`--model` selects a built-in translator route. It is mutually exclusive with `--provider`.
 
-* gpt3
+### OpenAI-compatible routes
 
-    
+| `--model` value | Behavior |
+|---|---|
+| `chatgptapi` | Default GPT-3.5-family preset/discovery route. |
+| `gpt4` | GPT-4 preset/discovery route. |
+| `gpt4omini` | GPT-4o-mini preset. |
+| `gpt4o` | GPT-4o preset. |
+| `gpt5mini` | GPT-5-mini preset. |
+| `o1preview`, `o1`, `o1mini`, `o3mini` | Matching reasoning-model presets. |
+| `openai` | Arbitrary OpenAI-compatible model IDs; requires `--model_list`. |
 
-        bbook_maker --book_name test_books/animal_farm.epub --model gpt3 --openai_key ${openai_key}
+Use `--openai_key` or, preferably, `BBM_OPENAI_API_KEY`. `OPENAI_API_KEY` remains supported
+for backward compatibility.
 
-    
+```sh
+bbook_maker --book_name book.epub --model openai \
+  --model_list gpt-4.1-mini --language ja
+```
 
-* chatgpiapi
+An OpenAI-compatible gateway can be selected with `--api_base`. The endpoint still has to
+serve the OpenAI chat-completions request shape.
 
+### Anthropic Claude
 
-    `chatgptapi` is [GPT-3.5-turbo](https://openai.com/blog/introducing-chatgpt-and-whisper-apis), which is used by ChatGPT currently.
+`claude` selects the translator's default Claude model. Exact built-in Claude IDs are also
+accepted, including the Claude 4/4.1/4.5/4.6 entries shown by `bbook_maker --help`.
+Because argparse validates `--model`, an arbitrary `claude-*` string is **not** accepted
+unless it is in that displayed list. Use `BBM_CLAUDE_API_KEY` (or `--claude_key`).
 
-        bbook_maker --book_name test_books/animal_farm.epub --model chatgptapi --openai_key ${openai_key}
+```sh
+bbook_maker --book_name book.epub --model claude-sonnet-4-6 --language zh-hans
+```
 
-* gpt4
+For an unlisted Claude ID on a gateway, use `--provider` or an OpenAI-compatible gateway
+with `--model openai --model_list ...`.
 
-    
+### Gemini
 
-        bbook_maker --book_name test_books/animal_farm.epub --model gpt4 --openai_key ${openai_key}
+- `--model gemini`: Gemini Flash route; accepts an exact comma-separated `--model_list`.
+- `--model geminipro`: Gemini Pro preset.
+- `--interval`: Gemini request interval in seconds.
 
-    If using `gpt4` , you can add `--use_context` to add a context paragraph to each passage sent to the model for translation.
+Use `BBM_GOOGLE_GEMINI_KEY` (or `--gemini_key`).
 
-  
+### Qwen-MT
 
-            
-        bbook_maker --book_name test_books/animal_farm.epub --model gpt4 --openai_key ${openai_key} --use_context
+- `--model qwen` defaults to `qwen-mt-turbo`.
+- `--model qwen-mt-turbo` selects the faster/cheaper MT model.
+- `--model qwen-mt-plus` selects the higher-quality MT model.
+- `--source_lang` sets the source language; its default is `auto`.
 
-    The option `--use_context` prompts the GPT4 model to create a one-paragraph summary. 
+Use `BBM_QWEN_API_KEY` (or `--qwen_key`).
 
-    
+### Other built-in routes
 
-    If it is the beginning of the translation, it will summarize the entire passage sent (the size depending on `--accumulated_num` ).
+| `--model` value | Credential |
+|---|---|
+| `groq` | `BBM_GROQ_API_KEY`; requires `--model_list`. |
+| `xai` | `BBM_XAI_API_KEY`. |
+| `google` | No API key. |
+| `caiyun` | `BBM_CAIYUN_API_KEY`. |
+| `deepl` | `BBM_DEEPL_API_KEY`. |
+| `deeplfree` | No API key. |
+| `tencentransmart` | No API key. |
+| `customapi` | `BBM_CUSTOM_API` (legacy custom translator). |
 
-    
+## Custom providers
 
-    If it has any proceeding passage, it will amend the summary to include details from the most recent passage, creating a running one-paragraph context payload of the important details of the entire translated work, which improves consistency of flow and tone of each translation.
+Use `--provider NAME` for a provider declared in project-level
+`./bbm_providers.json` or global `~/.bbm/providers.json`. A provider may use the `openai`,
+`claude`, `gemini`, or `qwen` API style and can supply a base URL, default model IDs, and
+the name of its key environment variable.
 
-* gpt5mini
+```sh
+bbook_maker --book_name book.epub --provider deepseek \
+  --model_list deepseek-chat --language zh-hans
+```
 
-    `gpt5mini` uses the `gpt-5-mini` model.
+Prefer the provider's configured environment variable. `--api_key` works but exposes a
+secret in shell history and process listings.
 
-        bbook_maker --book_name test_books/animal_farm.epub --model gpt5mini --openai_key ${openai_key}
+## Ollama
 
-**Note 1: Use `--openai_key` option to specify OpenAI API key. If you have multiple keys, separate them by commas (xxx, xxx, xxx) to reduce errors caused by API call limits.**
-
-**Note 2: You can just set the environment variable `BBM_OPENAI_API_KEY` instead the openai_key. See [Environment setting](settings.md).**
-
-### CAIYUN 
-
-Using Caiyun model to translate. The api currently only support: 
-
-        
-
-1. Simplified Chinese <-> English
-2. Simplified Chinese <-> Japanese
-
-The official Caiyun has provided a test token (3975l6lr5pcbvidl6jl2). You can apply your own token by following this [tutorial].(https://bobtranslate.com/service/translate/caiyun.html)
-
-            
-    bbook_maker --model caiyun --caiyun_key 3975l6lr5pcbvidl6jl2 --book_name test_books/animal_farm.epub
-
-### DEEPL
-
-There are two models you can choose from.
-
-    
-
-* deepl: [DeepL Translator](https://rapidapi.com/splintPRO/api/dpl-translator). <br>
-
-    
-
-    Need to pay to get the token. Use `--model deepl --deepl_key ${deepl_key}`
-
-        
-
-        bbook_maker --book_name test_books/animal_farm.epub --model deepl --deepl_key ${deepl_key}
-
-        
-
-* deeplfree: DeepL free model
-
-        
-
-        bbook_maker --book_name test_books/animal_farm.epub --model deeplfree
-
-### Claude
-
-Support [Claude](https://console.anthropic.com/docs) model. Use `--model claude --claude_key ${claude_key}` .
-
-    bbook_maker --book_name test_books/animal_farm.epub --model claude --claude_key ${claude_key}
-            
-
-### Custom API
-Support CustomAPI model. Use `--model customapi --custom_api ${custom_api}` .
-
-    bbook_maker --book_name test_books/animal_farm.epub --model customapi --custom_api ${custom_api}  
-
-### Google
-
-Support google model. Use `--model google`
+`--ollama_model MODEL` uses the local OpenAI-compatible Ollama endpoint. The default base
+is `http://localhost:11434/v1`; override it with `--api_base` for a remote server.
 
 ## Languages
-`--language <LANGUAGE>` <br>
 
-Set target languages. All models except for `caiyun` supports lots of languages. You can use `bbook_maker --help` to check available languages. Default target language is `"Simplified Chinese"` .
-
-```sh
-bbook_maker --book_name test_books/animal_farm.epub --model chatgptapi --openai_key ${openai_key} --language ja
-```
+`--language LANGUAGE` sets the target language and defaults to `zh-hans`. The accepted
+choices are generated from `book_maker/utils.py`; run the installed CLI to see the current
+list:
 
 ```sh
-bbook_maker --book_name test_books/animal_farm.epub --model chatgptapi --openai_key ${openai_key} --language "Simplified Chinese"
+bbook_maker --help
+bbook_maker --book_name book.epub --model google --language ja
 ```
+
+Not every provider supports every language accepted by the common parser. Provider-specific
+translators may map or reject unsupported source/target combinations.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,9 +3,9 @@ After successfully install the package, you can see `bbook-maker` is in the outp
 
 ## Preparation
 1. ChatGPT or OpenAI [token](https://platform.openai.com/account/api-keys)
-2. epub/txt books
+2. EPUB, TXT, Markdown, SRT, or PDF input
 3. Environment with internet access or proxy
-4. Python 3.8+
+4. Python 3.10+
 
 ## Use
 You can use by command `bbook_maker`. A sample book, `test_books/animal_farm.epub`, is provided for testing purposes.
@@ -23,7 +23,11 @@ python3 make_book.py --book_name ${path of a book} --openai_key ${openai_key}
 python3 make_book.py --book_name test_books/animal_farm.epub --openai_key ${openai_key}
 ```
 
-Once the translation is complete, a bilingual book named `${book_name}_bilingual.epub` would be generated.
+The output extension depends on the input loader. EPUB inputs produce
+`${book_name}_bilingual.epub`; TXT, Markdown, and SRT use their corresponding text/subtitle
+formats. PDF inputs always keep a bilingual TXT fallback and also attempt an EPUB, with
+optional PDF layouts selected by `--pdf_layout`.
 
-
-**Note: If there are any errors or you wish to interrupt the translation by pressing `CTRL+C`. A book named `${book_name}_bilingual_temp.epub` would be generated. You can simply rename it to any desired name.**
+Use `--resume` after an interruption. Loader-specific temporary output and checkpoint files
+are generated beside the source; do not rename a partial result as complete without checking
+it.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-from book_maker.cli import get_book_type
+from book_maker.cli import get_book_type, main
 
 
 def test_get_book_type_uses_final_suffix_and_lowercases():
@@ -8,6 +8,7 @@ def test_get_book_type_uses_final_suffix_and_lowercases():
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 REPO = Path(__file__).resolve().parent.parent
 BOOK = REPO / "test_books" / "animal_farm.epub"
@@ -192,3 +193,42 @@ def test_quiet_flag_is_accepted(tmp_path):
     proc, plan = _run(tmp_path, "--plan-dry-run", "--quiet")
     assert proc.returncode == 0
     assert plan.exists()
+
+
+def test_kobo_mode_does_not_require_book_name(tmp_path, monkeypatch):
+    src = tmp_path / BOOK.name
+    src.write_bytes(BOOK.read_bytes())
+    fake_obok = ModuleType("book_maker.obok")
+    fake_obok.cli_main = lambda device_path: str(src)
+    monkeypatch.setitem(sys.modules, "book_maker.obok", fake_obok)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "make_book.py",
+            "--book_from",
+            "kobo",
+            "--device_path",
+            "/mounted/kobo",
+            "--plan-dry-run",
+        ],
+    )
+
+    main()
+
+    assert (tmp_path / f"{src.stem}_plan.json").exists()
+
+
+def test_groq_model_list_does_not_use_openai_validation(monkeypatch):
+    from book_maker.translator.chatgptapi_translator import ChatGPTAPI
+    from book_maker.translator.groq_translator import GroqClient
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("OpenAI model validation must not run for Groq")
+
+    monkeypatch.setattr(ChatGPTAPI, "_validate_custom_models", fail_if_called)
+    client = object.__new__(GroqClient)
+    client.set_model_list(["llama-3.3-70b-versatile"])
+
+    assert client.model == "llama-3.3-70b-versatile"
+    assert next(client.model_list) == "llama-3.3-70b-versatile"

--- a/tests/test_cli_documentation.py
+++ b/tests/test_cli_documentation.py
@@ -1,0 +1,46 @@
+"""Keep the user-facing CLI references in sync with argparse."""
+
+import ast
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _long_cli_options() -> set[str]:
+    tree = ast.parse((ROOT / "book_maker/cli.py").read_text(encoding="utf-8"))
+    options: set[str] = set()
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_argument"
+        ):
+            continue
+        options.update(
+            arg.value
+            for arg in node.args
+            if isinstance(arg, ast.Constant)
+            and isinstance(arg.value, str)
+            and arg.value.startswith("--")
+        )
+    return options
+
+
+def _documented_options(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    # Avoid treating --batch_size as documentation for --batch.
+    return {
+        option
+        for option in _long_cli_options()
+        if re.search(re.escape(option) + r"(?![\w-])", text)
+    }
+
+
+def test_cli_references_mention_every_long_option():
+    expected = _long_cli_options()
+    for name in ("README.md", "README-CN.md", "docs/cmd.md"):
+        documented = _documented_options(ROOT / name)
+        assert (
+            documented == expected
+        ), f"{name} is missing CLI options: {sorted(expected - documented)}"


### PR DESCRIPTION
## Summary

- document all 54 long CLI options in the English README, Chinese README, and command reference
- refresh model routing, Python requirement, installed command, PDF/parallel/batch/quiet behavior, and retranslate argument guidance
- correct stale `--model_list`, `--parallel-workers`, and `--retranslate` help text
- make documented Groq `--model_list` work without querying OpenAI with a Groq key
- let Kobo mode resolve its source before `--book_name` validation
- warn when `--extra_body` is selected on a translator that does not consume it
- document ChatGPT's zero context-limit sentinel, SRT accumulation behavior, and the need to source `.env`
- add an AST-based regression test that fails when a new argparse option is missing from a CLI reference

This PR intentionally excludes the separate agent-integration documentation work.

## Tests

- `black --check .` (56 files unchanged)
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_cli_documentation.py tests/test_cli.py tests/test_provider_loader.py` (46 passed)
- full suite: 434 passed, 10 skipped, 3 xfailed; 2 unrelated integration failures remain (`PyDeepLX`/`httpx` incompatibility and an existing `gpt3` test using a removed CLI choice)
