### PR TITLE
test: make the default suite hermetic and run it on every PR

### DIFF
--- a/.github/workflows/make_test_ebook.yaml
+++ b/.github/workflows/make_test_ebook.yaml
@@ -42,6 +42,17 @@ jobs:
         run: |
             pip install .
 
+      # The default selection is hermetic — no network, no keys, no fixtures
+      # beyond test_books/ — so it runs on every PR, including forks, which
+      # receive none of the secrets the provider steps below depend on. It
+      # runs first because it is the fast, deterministic signal: ~40s, versus
+      # the live translation calls below. The live-provider suite deselects
+      # itself by marker (see pyproject.toml).
+      - name: Run the test suite
+        run: |
+            pip install pytest
+            pytest -q
+
       # The free Google endpoint rate-limits back-to-back runs from CI
       # runners. A failed run now exits nonzero instead of masking the
       # failure, so the known-transient refusals need a real retry here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,15 @@ requires = ["pdm-backend>=2.0.0"]
 build-backend = "pdm.backend"
 [tool.pdm.version]
 source = "scm"
+
+[tool.pytest.ini_options]
+markers = [
+    "live_provider: calls a real translation provider (needs keys and network; run with -m live_provider)",
+]
+# live_provider is about the network, not about scope: the CLI contract
+# tests are integration tests too, and they stay in the default run because
+# they go through an offline stand-in. What deselects here is spending real
+# quota — a bare `pytest` must not, and on a fork's CI run there is neither
+# key nor secret to spend. Asked for by name; the default selection is
+# hermetic.
+addopts = "-m 'not live_provider'"

--- a/tests/hermetic/sitecustomize.py
+++ b/tests/hermetic/sitecustomize.py
@@ -1,0 +1,50 @@
+"""Offline stand-in for the `google` translator, for CLI contract tests.
+
+Python imports `sitecustomize` at interpreter startup, so putting this
+directory on PYTHONPATH swaps the translator *before* `make_book.py` runs.
+The subprocess still exercises the real CLI: argument parsing, mode
+selection, loader wiring, output writing — everything except the network
+call, which is the one part those tests were never about.
+
+Why it matters: the CLI suite used to translate through the public Google
+endpoint, so a proxy hiccup (observed: HTTP 502) failed tests that have
+nothing to do with translation quality, and a run with no network could not
+pass at all. Live translation is covered by tests/test_integration.py, which
+is explicitly about talking to real providers.
+"""
+
+from book_maker.translator import MODEL_DICT
+
+
+class OfflineTranslator:
+    """Deterministic, no network. Mirrors the surface the loaders call."""
+
+    TRANSLATION_ERROR_MARKER = None
+
+    def __init__(self, *args, **kwargs):
+        self._fatal_error_detected = False
+        self.is_test = False
+
+    def rotate_key(self):
+        pass
+
+    def set_deployment_id(self, *args, **kwargs):
+        pass
+
+    def set_interval(self, *args, **kwargs):
+        pass
+
+    def set_model_list(self, *args, **kwargs):
+        pass
+
+    def translate(self, text, *args, **kwargs):
+        return f"[offline]{text}"
+
+    def translate_list(self, texts, *args, **kwargs):
+        return [self.translate(str(t)) for t in texts]
+
+    def translate_and_split_lines(self, text, *args, **kwargs):
+        return [self.translate(line) for line in str(text).splitlines()]
+
+
+MODEL_DICT["google"] = OfflineTranslator

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ def test_get_book_type_uses_final_suffix_and_lowercases():
     assert get_book_type("/tmp/books/source.v1.README.MD") == "md"
 
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +13,21 @@ from types import ModuleType
 
 REPO = Path(__file__).resolve().parent.parent
 BOOK = REPO / "test_books" / "animal_farm.epub"
+# tests/hermetic/sitecustomize.py swaps the `google` translator for an
+# offline one at interpreter startup. These are CLI *contract* tests — flag
+# wiring, mode selection, what gets written — and routing them through a
+# public translation endpoint made them fail on proxy errors (observed:
+# HTTP 502) and impossible to run offline at all. Live provider calls belong
+# to tests/test_integration.py, which is explicitly about talking to them.
+HERMETIC = Path(__file__).resolve().parent / "hermetic"
+
+
+def _env():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(HERMETIC), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    return env
 
 
 def _run(tmp_path, *args):
@@ -30,6 +46,7 @@ def _run(tmp_path, *args):
         cwd=REPO,
         capture_output=True,
         text=True,
+        env=_env(),
     )
     return proc, src.parent / (src.stem + "_plan.json")
 
@@ -121,6 +138,7 @@ def test_classify_flag_rejects_non_epub_books(tmp_path):
         cwd=REPO,
         capture_output=True,
         text=True,
+        env=_env(),
     )
     assert proc.returncode == 1
     assert "epub-only" in proc.stdout

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,13 @@ from pathlib import Path
 
 import pytest
 
+# every test here shells out to a real provider: live network, real keys,
+# real quota. Deselected from the default run and asked for by name. The
+# marker names the network dependency, not the test's scope — the CLI
+# contract tests are integration tests too and stay in the default run,
+# because they translate through an offline stand-in.
+pytestmark = pytest.mark.live_provider
+
 
 @pytest.fixture()
 def test_book_dir() -> str:

--- a/tests/test_pdf_cli.py
+++ b/tests/test_pdf_cli.py
@@ -1,9 +1,26 @@
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
 fitz = pytest.importorskip("fitz")
+
+# Same offline stand-in test_cli.py uses: tests/hermetic/sitecustomize.py
+# swaps the `google` translator at interpreter startup. This test is about
+# what the CLI writes for a PDF input, not about translation quality, and
+# routing it through the public endpoint made it fail whenever that endpoint
+# rate-limited the run — the flake the retry wrapper exists to paper over.
+HERMETIC = Path(__file__).resolve().parent / "hermetic"
+
+
+def _env():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(HERMETIC), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    return env
 
 
 def test_pdf_cli_creates_txt_and_optional_epub(tmp_path):
@@ -27,11 +44,15 @@ def test_pdf_cli_creates_txt_and_optional_epub(tmp_path):
             "google",
         ],
         check=True,
+        env=_env(),
     )
 
     txt_out = tmp_path / "cli_test_bilingual.txt"
     assert txt_out.exists()
     assert txt_out.stat().st_size > 0
+    # the stand-in's marker: proof the CLI wrote a *translation*, which a
+    # size check alone never established
+    assert "[offline]" in txt_out.read_text(encoding="utf-8")
 
     # if ebooklib is installed, an epub should be created
     try:

--- a/tests/test_pdf_layout.py
+++ b/tests/test_pdf_layout.py
@@ -1,7 +1,17 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from book_maker.loader.pdf_loader import create_bilingual_pdf
+
+# `--pdf_layout` is an opt-in output format and reportlab is declared in no
+# requirements file, so `create_bilingual_pdf` reports the missing import and
+# returns False rather than breaking a translation run. Asserting that return
+# value without the dependency turns "optional extra absent" into a failing
+# test on every clean checkout — the same importorskip guard test_pdf_cli.py
+# uses for fitz.
+pytest.importorskip("reportlab")
 
 
 def _run_check(tmp_dir):


### PR DESCRIPTION
CI never ran the test suite. The workflow's only checks were `black --check` and a handful of live translation calls guarded by secrets — which a PR from a fork does not receive. So a fork's PR got no functional signal at all, and a branch PR got one only where the free Google endpoint happened to cooperate.

The suite could not simply be switched on, because parts of it were not hermetic. This makes them hermetic, then switches it on.

### What changes

**`tests/hermetic/sitecustomize.py`** — an offline stand-in for the `google` translator. Python imports `sitecustomize` at interpreter startup, so putting that directory on `PYTHONPATH` swaps `MODEL_DICT["google"]` *before* `make_book.py` runs. The subprocess still exercises the real CLI — argument parsing, mode selection, loader wiring, output writing — everything except the network call, which is the one part those tests were never about.

`tests/test_cli.py` and `tests/test_pdf_cli.py` shelled out to `make_book.py --model google`, so every test in them translated through the public endpoint. A proxy hiccup (observed: HTTP 502) failed tests that have nothing to do with translation quality, and a machine with no network could not run them at all. They now route through the stand-in. `test_pdf_cli.py` additionally asserts the stand-in's `[offline]` marker appears in the output — proof the CLI wrote a *translation*, which the previous size-only check never established.

**`live_provider` marker** — `tests/test_integration.py` shells out to real providers on every test: live network, real keys, real quota. That is deliberate and worth keeping, but it must not be what a bare `pytest` does, least of all on a fork's CI run with no secrets to spend. The module is marked and deselected by default; `pytest -m live_provider` asks for it by name.

The marker names the network dependency, not the test's scope — the CLI contract tests are integration tests too, and they stay in the default run precisely because they no longer touch the network.

**`tests/test_pdf_layout.py`** — `reportlab` is declared in no requirements file, and `create_bilingual_pdf` deliberately reports the missing import and returns `False` rather than breaking a translation run. Asserting that return value without the dependency installed turned "optional extra absent" into a failing test on every clean checkout. Guarded with the same `importorskip` `test_pdf_cli.py` already uses for `fitz`.

**CI** — `pytest -q` runs first, before the live steps: no network, no keys, no fixtures beyond `test_books/`, so it works on forks. It is the fast deterministic signal, ~40s, ahead of the live translation calls that follow.

### Verification

`pytest -q` on this branch: **426 passed, 8 skipped, 3 xfailed, 0 failed** — with no provider keys set. `pytest -m live_provider` selects the 12 integration tests. `black . --check` clean.

Test and CI only; no library code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)