### PR TITLE
feat: add OrcaRouter as a named provider

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -94,6 +94,16 @@ bbook_maker --book_name test_books/animal_farm.epub --openai_key ${openai_key} -
   python3 make_book.py --book_name test_books/animal_farm.epub --model xai --xai_key ${xai_key}
   ```
 
+* [OrcaRouter](https://www.orcarouter.ai)
+
+  支持 [OrcaRouter](https://www.orcarouter.ai) 网关，默认使用 `orcarouter/auto` 智能路由模型。
+  它在同一端点上为 AI 代理提供网关级的零信任安全——默认拒绝地筛查每个 prompt/response
+  并管控每个工具调用，无需改任何应用代码。
+
+  ```shell
+  python3 make_book.py --book_name test_books/animal_farm.epub --model orcarouter --orcarouter_key ${orcarouter_key}
+  ```
+
 * [Ollama](https://github.com/ollama/ollama)
 
   使用 [Ollama](https://github.com/ollama/ollama) 自托管模型进行翻译。

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The bilingual_book_maker is an AI translation tool that uses ChatGPT to assist u
 ## Supported models
 
 Built-in routes include OpenAI presets and arbitrary OpenAI-compatible model IDs, current
-Claude choices, Gemini, Qwen-MT, Groq, xAI, DeepL, Google, Caiyun, and Tencent TranSmart.
+Claude choices, Gemini, Qwen-MT, Groq, xAI, OrcaRouter, DeepL, Google, Caiyun, and Tencent TranSmart.
 The exact `--model` choices come from the installed version, so use
 `python3 make_book.py --help`. Unlisted gateways and native-provider model IDs can be
 configured with `--provider`; see [Models and languages](./docs/model_lang.md).
@@ -110,6 +110,17 @@ bbook_maker --book_name test_books/animal_farm.epub --openai_key ${openai_key} -
   python3 make_book.py --book_name test_books/animal_farm.epub --model xai --xai_key ${xai_key}
   ```
 
+* [OrcaRouter](https://www.orcarouter.ai)
+
+  Support [OrcaRouter](https://www.orcarouter.ai) gateway, defaulting to the
+  `orcarouter/auto` smart-routing model. It also runs gateway-level, zero-trust
+  security for AI agents on the same endpoint — screening every prompt/response and
+  governing every tool call on a default-deny basis, with no application code changes.
+
+  ```shell
+  python3 make_book.py --book_name test_books/animal_farm.epub --model orcarouter --orcarouter_key ${orcarouter_key}
+  ```
+
 * [Ollama](https://github.com/ollama/ollama)
 
   Support [Ollama](https://github.com/ollama/ollama) self-host models,
@@ -202,6 +213,7 @@ bbook_maker --book_name test_books/animal_farm.epub --openai_key ${openai_key} -
   | `geminipro` | `--gemini_key` / `BBM_GOOGLE_GEMINI_KEY` | Gemini Pro |
   | `groq` | `--groq_key` / `BBM_GROQ_API_KEY` | **Requires `--model_list`** |
   | `xai` | `--xai_key` / `BBM_XAI_API_KEY` | Grok |
+  | `orcarouter` | `--orcarouter_key` / `BBM_ORCAROUTER_API_KEY` | OrcaRouter smart routing; defaults to `orcarouter/auto` |
   | `qwen-mt-turbo` | `--qwen_key` / `BBM_QWEN_API_KEY` | Qwen fast translation model |
   | `qwen-mt-plus` | `--qwen_key` / `BBM_QWEN_API_KEY` | Qwen high-quality translation model |
   | `google` | N/A | Free. No API key needed |

--- a/book_maker/cli.py
+++ b/book_maker/cli.py
@@ -193,6 +193,14 @@ def main():
         help="You can get xAI Key from  https://console.x.ai/",
     )
 
+    # for OrcaRouter
+    parser.add_argument(
+        "--orcarouter_key",
+        dest="orcarouter_key",
+        type=str,
+        help="You can get OrcaRouter Key from  https://www.orcarouter.ai",
+    )
+
     # for Qwen
     parser.add_argument(
         "--qwen_key",
@@ -651,6 +659,10 @@ So you are close to reaching the limit. You have to choose your own value, there
         API_KEY = options.groq_key or env.get("BBM_GROQ_API_KEY")
     elif options.model == "xai":
         API_KEY = options.xai_key or env.get("BBM_XAI_API_KEY")
+    elif options.model == "orcarouter":
+        API_KEY = options.orcarouter_key or env.get("BBM_ORCAROUTER_API_KEY")
+        if not API_KEY:
+            raise Exception("Please provide orcarouter key")
     elif options.model and options.model.startswith("qwen"):
         # "qwen" itself is a MODEL_DICT choice; matching only "qwen-" left it
         # with an empty key, so the documented alias could never authenticate.
@@ -726,6 +738,7 @@ So you are close to reaching the limit. You have to choose your own value, there
             "o1mini",
             "o3mini",
             "xai",
+            "orcarouter",
         }
         supports_extra_body = options.model in openai_models or (
             options.provider

--- a/book_maker/translator/__init__.py
+++ b/book_maker/translator/__init__.py
@@ -9,6 +9,7 @@ from book_maker.translator.groq_translator import GroqClient
 from book_maker.translator.tencent_transmart_translator import TencentTranSmart
 from book_maker.translator.custom_api_translator import CustomAPI
 from book_maker.translator.xai_translator import XAIClient
+from book_maker.translator.orcarouter_translator import OrcaRouterTranslator
 from book_maker.translator.qwen_translator import QwenTranslator
 
 MODEL_DICT = {
@@ -41,6 +42,7 @@ MODEL_DICT = {
     "tencentransmart": TencentTranSmart,
     "customapi": CustomAPI,
     "xai": XAIClient,
+    "orcarouter": OrcaRouterTranslator,
     "qwen": QwenTranslator,
     "qwen-mt-turbo": QwenTranslator,
     "qwen-mt-plus": QwenTranslator,

--- a/book_maker/translator/orcarouter_translator.py
+++ b/book_maker/translator/orcarouter_translator.py
@@ -1,0 +1,21 @@
+from openai import OpenAI
+from .chatgptapi_translator import ChatGPTAPI
+
+# orcarouter/auto is OrcaRouter's smart routing endpoint: it picks the best
+# model for each request instead of pinning one. Specific model IDs can be
+# used through `--model openai --api_base https://api.orcarouter.ai/v1`.
+ORCAROUTER_MODEL_LIST = [
+    "orcarouter/auto",
+]
+
+
+class OrcaRouterTranslator(ChatGPTAPI):
+    def __init__(self, key, language, api_base=None, **kwargs) -> None:
+        super().__init__(key, language)
+        self.model_list = ORCAROUTER_MODEL_LIST
+        self.api_url = str(api_base) if api_base else "https://api.orcarouter.ai/v1"
+        self.api_base = self.api_url
+        self.openai_client = OpenAI(api_key=key, base_url=self.api_url)
+
+    def rotate_model(self):
+        self.model = self.model_list[0]

--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -75,6 +75,7 @@ sections after it provide additional notes for selected workflows.
 | `--gemini_key KEY` | Gemini key; prefer `BBM_GOOGLE_GEMINI_KEY`. |
 | `--groq_key KEY` | Groq key; prefer `BBM_GROQ_API_KEY`. |
 | `--xai_key KEY` | xAI key; prefer `BBM_XAI_API_KEY`. |
+| `--orcarouter_key KEY` | OrcaRouter key; prefer `BBM_ORCAROUTER_API_KEY`. |
 | `--qwen_key KEY` | Qwen key; prefer `BBM_QWEN_API_KEY`. |
 | `--deepl_key KEY` | DeepL key; prefer `BBM_DEEPL_API_KEY`. |
 | `--caiyun_key KEY` | Caiyun key; prefer `BBM_CAIYUN_API_KEY`. |

--- a/docs/model_lang.md
+++ b/docs/model_lang.md
@@ -68,6 +68,7 @@ Use `BBM_QWEN_API_KEY` (or `--qwen_key`).
 |---|---|
 | `groq` | `BBM_GROQ_API_KEY`; requires `--model_list`. |
 | `xai` | `BBM_XAI_API_KEY`. |
+| `orcarouter` | `BBM_ORCAROUTER_API_KEY`. Defaults to the `orcarouter/auto` smart-routing model; override the endpoint with `--api_base https://api.orcarouter.ai/v1`. |
 | `google` | No API key. |
 | `caiyun` | `BBM_CAIYUN_API_KEY`. |
 | `deepl` | `BBM_DEEPL_API_KEY`. |

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -561,6 +561,29 @@ def test_groq_never_probes_for_structured_outputs():
 
 
 # --------------------------------------------------------------------------
+# OrcaRouter: named OpenAI-compatible gateway route
+# --------------------------------------------------------------------------
+
+
+def test_orcarouter_uses_orca_endpoint_and_default_model():
+    from book_maker.translator.orcarouter_translator import OrcaRouterTranslator
+
+    translator = OrcaRouterTranslator("sk-orca-test", "Chinese")
+    assert translator.api_base == "https://api.orcarouter.ai/v1"
+    assert translator.openai_client.base_url == "https://api.orcarouter.ai/v1/"
+    translator.rotate_model()
+    assert translator.model == "orcarouter/auto"
+
+
+def test_orcarouter_honors_custom_api_base():
+    from book_maker.translator.orcarouter_translator import OrcaRouterTranslator
+
+    translator = OrcaRouterTranslator("sk-orca-test", "Chinese", api_base="http://proxy.local/v1")
+    assert translator.api_base == "http://proxy.local/v1"
+    assert translator.openai_client.base_url == "http://proxy.local/v1/"
+
+
+# --------------------------------------------------------------------------
 # Item 6: temperature must not be forced onto models that only accept their
 # default, and a temperature 400 must not be blamed on the JSON schema
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Add [OrcaRouter](https://www.orcarouter.ai) as a built-in `--model` route, mirroring the existing xAI wiring.

- New `OrcaRouterTranslator` (`book_maker/translator/orcarouter_translator.py`) that points at `https://api.orcarouter.ai/v1` and defaults to the `orcarouter/auto` smart-routing model.
- CLI: new `--orcarouter_key` flag / `BBM_ORCAROUTER_API_KEY` env var.
- Registered in `MODEL_DICT` so `--model orcarouter` is a valid choice.
- Docs: README (EN/CN), `docs/cmd.md`, `docs/model_lang.md`.

OrcaRouter is an OpenAI-compatible model gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Usage

```sh
python3 make_book.py --book_name test_books/animal_farm.epub --model orcarouter --orcarouter_key ${orcarouter_key}
```

## Verification

- `pytest` full suite: 427 passed, 1 pre-existing hermetic-env failure (`test_pdf_cli.py`) that also fails on the clean `main` tree in this sandbox (unrelated to this change).
- New unit tests pass: base URL, default model rotation, custom `--api_base` override.
- L3 live test: real request through the new translator against `https://api.orcarouter.ai/v1` returned a successful translation.

Disclosure: I'm an engineer on the OrcaRouter team.
