### PR TITLE
Fix: a refused paragraph ends the whole book

### DIFF
--- a/book_maker/translator/chatgptapi_translator.py
+++ b/book_maker/translator/chatgptapi_translator.py
@@ -26,6 +26,7 @@ from openai import (
 )
 from pydantic import ConfigDict, Field, ValidationError, create_model
 from rich import print
+from rich.markup import escape
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -57,6 +58,20 @@ class StructuredOutputUnsupported(Exception):
     Raised only for capability answers, never for model or transport errors, so
     callers can demote to the delimiter method instead of retrying.
     """
+
+
+class StructuredRefusal(Exception):
+    """The model declined to answer this particular text.
+
+    Deliberately not a `StructuredOutputUnsupported`: a refusal says nothing
+    about whether the endpoint honors the schema, and counting it as a
+    capability failure would demote structured outputs for the whole run after
+    two paragraphs. Callers retranslate the one paragraph without a schema.
+    """
+
+    def __init__(self, refusal):
+        super().__init__(f"Model refused to translate: {refusal}")
+        self.refusal = refusal
 
 
 # The schema is the last thing the model reads before it decodes, and a bare
@@ -767,7 +782,8 @@ class ChatGPTAPI(Base):
 
         Raises `StructuredOutputUnsupported` when the endpoint turns out not to
         honor the schema, `LengthFinishReasonError` when the answer was cut off
-        (never returns the truncated JSON fragment), and `ValueError` on refusal.
+        (never returns the truncated JSON fragment), and `StructuredRefusal`
+        when the model declined this text.
         """
         messages = self.create_messages(text, self.create_context_messages())
         field = single_field_name(self.language)
@@ -792,7 +808,7 @@ class ChatGPTAPI(Base):
 
         message = completion.choices[0].message
         if getattr(message, "refusal", None):
-            raise ValueError(f"Model refused to translate: {message.refusal}")
+            raise StructuredRefusal(message.refusal)
         if message.parsed is None:
             raise StructuredOutputUnsupported("no parsed content in response")
 
@@ -827,6 +843,16 @@ class ChatGPTAPI(Base):
                 print(
                     "[yellow]ℹ structured answer was truncated; retranslating "
                     "this paragraph without a schema[/yellow]"
+                )
+                t_text = self._plain_translation(text)
+            except StructuredRefusal as e:
+                # Seen live with the refusal field holding a complete, correct
+                # translation. Whatever the reason, one paragraph the schema
+                # path will not answer must not end the run.
+                print(
+                    "[yellow]ℹ the model refused this paragraph under the "
+                    f"schema ({escape(str(e.refusal))}); retranslating it "
+                    "without one[/yellow]"
                 )
                 t_text = self._plain_translation(text)
         else:
@@ -1009,7 +1035,9 @@ class ChatGPTAPI(Base):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=60),
-        retry=retry_if_not_exception_type(StructuredOutputUnsupported),
+        retry=retry_if_not_exception_type(
+            (StructuredOutputUnsupported, StructuredRefusal)
+        ),
         reraise=True,
     )
     def _execute_structured_batch_translate(self, text_list, plist_len):
@@ -1045,7 +1073,7 @@ class ChatGPTAPI(Base):
 
         message = completion.choices[0].message
         if getattr(message, "refusal", None):
-            raise ValueError(f"Model refused to translate: {message.refusal}")
+            raise StructuredRefusal(message.refusal)
         if message.parsed is None:
             raise StructuredOutputUnsupported("no parsed content in response")
 

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -21,6 +21,7 @@ from book_maker.structured import StructuredJSONFailed
 from book_maker.translator.chatgptapi_translator import (
     ChatGPTAPI,
     StructuredOutputUnsupported,
+    StructuredRefusal,
     batch_field_name,
     batch_translation_model,
     single_field_name,
@@ -455,14 +456,52 @@ def test_truncation_retranslates_plainly_instead_of_ending_the_run():
     assert translator._structured_support["test-model"] == "strict"
 
 
-def test_refusal_raises_loudly():
+def test_refusal_raises_its_own_exception():
+    """A refusal is its own answer — neither a capability verdict nor a
+    transport error, so it gets an exception the caller can act on."""
     translator = _translator(
         parse=Mock(return_value=_parsed_completion(refusal="nope"))
     )
     translator._structured_support["test-model"] = "strict"
 
-    with pytest.raises(ValueError, match="refused"):
+    with pytest.raises(StructuredRefusal, match="nope"):
         translator._structured_single_translation("hello")
+
+
+def test_refusal_retranslates_plainly_instead_of_ending_the_run():
+    """Observed live: the refusal field held a complete, correct translation
+    while tenacity retried three times and then killed the book. One paragraph
+    the schema path would not answer goes through the plain path instead."""
+    create = Mock(return_value=_completion("完整的翻譯"))
+    translator = _translator(
+        create=create,
+        parse=Mock(return_value=_parsed_completion(refusal="I cannot help")),
+    )
+    translator._structured_support["test-model"] = "strict"
+
+    assert translator.get_translation("hello") == "完整的翻譯"
+    assert create.call_count == 1
+    # A refusal says nothing about schema support: demoting on it would cost
+    # the rest of the book its structured mode after two paragraphs.
+    assert translator._structured_support["test-model"] == "strict"
+
+
+def test_batch_refusal_is_not_retried_before_falling_back():
+    """The batch caller already degrades to one-by-one; retrying a refusal
+    three times first only buys three more refusals."""
+    parse = Mock(return_value=_parsed_completion(refusal="nope"))
+    create = Mock(return_value=_completion("plain"))
+    translator = _translator(create=create, parse=parse)
+    translator._structured_support["test-model"] = "strict"
+
+    assert translator._do_structured_batch_translate(["a", "b"]) == ["plain"] * 2
+
+    batch_model = batch_translation_model(LANGUAGE)
+    batch_calls = [
+        c for c in parse.call_args_list if c.kwargs["response_format"] is batch_model
+    ]
+    assert len(batch_calls) == 1
+    assert translator._structured_support["test-model"] == "strict"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_chatgptapi_translator.py
+++ b/tests/test_chatgptapi_translator.py
@@ -617,7 +617,9 @@ def test_orcarouter_uses_orca_endpoint_and_default_model():
 def test_orcarouter_honors_custom_api_base():
     from book_maker.translator.orcarouter_translator import OrcaRouterTranslator
 
-    translator = OrcaRouterTranslator("sk-orca-test", "Chinese", api_base="http://proxy.local/v1")
+    translator = OrcaRouterTranslator(
+        "sk-orca-test", "Chinese", api_base="http://proxy.local/v1"
+    )
     assert translator.api_base == "http://proxy.local/v1"
     assert translator.openai_client.base_url == "http://proxy.local/v1/"
 


### PR DESCRIPTION
### What happens now

Translating Orwell's *Animal Farm* into zh-hant on `gpt-4.1-mini`, the run
died on paragraph 5 with `Model refused to translate: ...` — and the refusal
field held a **complete, correct translation of the paragraph**.

Whatever makes a model put its answer there rather than in the parsed field,
one paragraph should not end a multi-hour book run.

### Why one refusal costs the run

`_structured_single_translation` raises a bare `ValueError` on any non-empty
`message.refusal`. Nothing catches it, and `get_translation`'s retry policy is

```python
retry=retry_if_exception_type((RateLimitError, Exception))
```

which catches everything — so tenacity retried three times and reraised. A
model that refuses a paragraph once refuses it three times, so the retries
only slow the failure down.

### The change

A refusal is neither a capability verdict nor a transport error, so it gets
its own exception, and `get_translation` handles it beside the truncation arm
that is already there:

```python
except LengthFinishReasonError:
    ...  # existing: retranslate without a schema
except StructuredRefusal as e:
    ...  # new: same recovery, same reason
```

Same shape of recovery for the same shape of problem — the schema path cannot
deliver this paragraph, the plain path still can.

Two deliberate details:

- **`StructuredRefusal` does not subclass `StructuredOutputUnsupported`.** A
  refusal says nothing about whether the endpoint honors the schema. Routing
  it through the capability exception would trip the two-strike demote streak
  and cost the rest of the run its structured mode.
- **On the batch path it is excluded from the retry rather than caught.**
  `_do_structured_batch_translate` already degrades to one-by-one
  translation, so the only thing three retries bought there was three more
  refusals.

### Tests

`test_refusal_raises_loudly` pinned the old behaviour and is rewritten. Added
a fallback test modelled on the existing truncation one, and a batch test
(there was no refusal coverage on that path). Full suite green: 430 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)