### PR TITLE
docker: publish multi-arch images to GHCR, modernize the Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,10 @@
-Dockerfile*
-docker-compose*
-LICENSE
-test_books
-README*
-.dockerignore
-.git
-.github
-.gitignore
-.vscode
+# Allowlist: exclude everything, then re-include exactly what the image needs.
+*
+
+!book_maker
+!make_book.py
+!requirements.txt
+
+# ...minus anything that should never travel inside the allowed paths.
+book_maker/**/__pycache__
+book_maker/**/*.py[cod]

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,68 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+# One build per ref. Pull request builds are superseded by newer pushes;
+# builds for main and for tags are left to finish so a release is never
+# cancelled halfway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Pull requests build but never push, so a fork PR needs no credentials.
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          # metadata-action lowercases the repository name for us.
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release and Build Docker Image
+name: Release PyPI
 
 permissions:
   contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,39 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
-RUN apt-get update
+LABEL org.opencontainers.image.source="https://github.com/yihong0618/bilingual_book_maker" \
+      org.opencontainers.image.description="AI translation tool that creates bilingual epub/txt/srt/md books" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /app
 
-COPY requirements.txt .
+# Dependencies first, so the (slow) install layer is cached across code changes.
+# requirements.txt is a complete hash-pinned lock export, which puts pip in
+# hash-checking mode; every dependency ships manylinux wheels for amd64 and
+# arm64, so no apt packages and no compiler are needed.
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
-RUN pip install -r /app/requirements.txt
+COPY book_maker/ ./book_maker/
+COPY make_book.py ./
 
-COPY . .
+RUN groupadd --gid 1000 bbm \
+    && useradd --uid 1000 --gid 1000 --no-create-home --shell /usr/sbin/nologin bbm \
+    # The CLI writes two directories relative to the working directory:
+    # log/buglog.txt on every epub run, and batch_files/ on the openai batch
+    # route. Pre-create them writable; /app itself stays root-owned so the
+    # container cannot rewrite its own code. Group root + g+w keeps them
+    # writable under `docker run --user <uid>` too, since an overridden uid
+    # still runs with gid 0.
+    && mkdir -p /app/log /app/batch_files \
+    && chown 1000:0 /app/log /app/batch_files \
+    && chmod 775 /app/log /app/batch_files
+USER 1000:1000
 
-ENTRYPOINT ["python3", "make_book.py"]
+# argv is passed through verbatim, so every CLI flag works unchanged.
+ENTRYPOINT ["python", "make_book.py"]
+CMD ["--help"]

--- a/README-CN.md
+++ b/README-CN.md
@@ -615,6 +615,51 @@ python3 make_book.py --book_name 'animal_farm.epub' --key XXXXX --api_base 'http
 python make_book.py --book_name 'animal_farm.epub' --key XXXXX --api_base 'https://example-endpoint.openai.azure.com/openai/v1' --model 'deployment-name' --use_context session
 ```
 
+## Docker
+
+如果不想配置本地环境，可以直接使用 [Docker](https://www.docker.com/)。每次合并到 `main`（对应 `latest` 标签）以及每次发布版本标签时，都会自动构建镜像并发布到 GitHub Container Registry：
+
+```shell
+docker pull ghcr.io/yihong0618/bilingual_book_maker:latest
+```
+
+把书所在的文件夹挂载到 `/book`，其余参数与 `make_book.py` 完全一致（所有命令行参数都支持），翻译结果会写回同一文件夹：
+
+```shell
+# Linux / macOS
+export folder_path=/path/to/your/books
+export book_name=animal_farm.epub
+export openai_key=sk-XXX
+export language=zh-hans   # 语言列表见 book_maker/utils.py
+
+docker run --rm -v "${folder_path}":/book ghcr.io/yihong0618/bilingual_book_maker:latest --book_name "/book/${book_name}" --key "${openai_key}" --language "${language}"
+```
+
+```powershell
+# Windows PowerShell
+$folder_path="C:\Users\user\mybook"
+$book_name="animal_farm.epub"
+$openai_key="sk-xxx"
+$language="zh-hans"
+
+docker run --rm -v ${folder_path}:/book ghcr.io/yihong0618/bilingual_book_maker:latest --book_name "/book/$book_name" --key $openai_key --language $language
+```
+
+例如，走免费的 Google 翻译路线做个不需要任何 key 的快速测试：
+
+```shell
+docker run --rm -v /home/user/my_books:/book ghcr.io/yihong0618/bilingual_book_maker:latest --book_name /book/animal_farm.epub --api_format google --test --test_num 1 --language zh-hant
+```
+
+容器以非 root 用户（uid 1000）运行。在 Linux 上，如果挂载的文件夹对该 uid 不可写，加上 `--user $(id -u)`（只写 uid 即可——镜像内部目录对组保持可写，正是为了这种情况）。API key 也可以用环境变量传入（`-e OPENAI_API_KEY=sk-XXX`）来代替 `--key`。
+
+如果想自己构建镜像而不是拉取：
+
+```shell
+docker build --tag bilingual_book_maker .
+docker run --rm -v /path/to/your/books:/book bilingual_book_maker --book_name /book/animal_farm.epub --key sk-XXX --language zh-hans
+```
+
 ## 注意
 
 1. Free trail 的 API token 有所限制，如果想要更快的速度，可以考虑付费方案

--- a/README.md
+++ b/README.md
@@ -708,37 +708,47 @@ python make_book.py --book_name 'animal_farm.epub' --key XXXXX --api_base 'https
 
 ## Docker
 
-You can use [Docker](https://www.docker.com/) if you don't want to deal with setting up the environment.
+You can use [Docker](https://www.docker.com/) if you don't want to deal with setting up the environment. Prebuilt images are published to GitHub Container Registry on every merge to `main` (as `latest`) and on every release tag:
 
 ```shell
-# Build image
-docker build --tag bilingual_book_maker .
-
-# Run container
-# "$folder_path" represents the folder where your book file locates. Also, it is where the processed file will be stored.
-
-# Windows PowerShell
-$folder_path=your_folder_path # $folder_path="C:\Users\user\mybook\"
-$book_name=your_book_name # $book_name="animal_farm.epub"
-$openai_key=your_api_key # $openai_key="sk-xxx"
-$language=your_language # see utils.py
-
-docker run --rm --name bilingual_book_maker --mount type=bind,source=$folder_path,target='/app/test_books' bilingual_book_maker --book_name "/app/test_books/$book_name" --key $openai_key --language $language
-
-# Linux
-export folder_path=${your_folder_path}
-export book_name=${your_book_name}
-export openai_key=${your_api_key}
-export language=${your_language}
-
-docker run --rm --name bilingual_book_maker --mount type=bind,source=${folder_path},target='/app/test_books' bilingual_book_maker --book_name "/app/test_books/${book_name}" --key ${openai_key} --language "${language}"
+docker pull ghcr.io/yihong0618/bilingual_book_maker:latest
 ```
 
-For example:
+Mount the folder containing your book at `/book` and pass the usual flags — the container accepts every `make_book.py` option, and the translated book is written back into the same folder:
 
 ```shell
-# Linux
-docker run --rm --name bilingual_book_maker --mount type=bind,source=/home/user/my_books,target='/app/test_books' bilingual_book_maker --book_name /app/test_books/animal_farm.epub --key sk-XXX --test --test_num 1 --language zh-hant
+# Linux / macOS
+export folder_path=/path/to/your/books
+export book_name=animal_farm.epub
+export openai_key=sk-XXX
+export language=zh-hans   # see the language list in book_maker/utils.py
+
+docker run --rm -v "${folder_path}":/book ghcr.io/yihong0618/bilingual_book_maker:latest --book_name "/book/${book_name}" --key "${openai_key}" --language "${language}"
+```
+
+```powershell
+# Windows PowerShell
+$folder_path="C:\Users\user\mybook"
+$book_name="animal_farm.epub"
+$openai_key="sk-xxx"
+$language="zh-hans"
+
+docker run --rm -v ${folder_path}:/book ghcr.io/yihong0618/bilingual_book_maker:latest --book_name "/book/$book_name" --key $openai_key --language $language
+```
+
+For example, a quick test needing no key at all, over the free Google route:
+
+```shell
+docker run --rm -v /home/user/my_books:/book ghcr.io/yihong0618/bilingual_book_maker:latest --book_name /book/animal_farm.epub --api_format google --test --test_num 1 --language zh-hant
+```
+
+The container runs as a non-root user (uid 1000). On Linux, if the mounted folder is not writable for that uid, add `--user $(id -u)` (uid only — the image keeps its internal directories group-writable for exactly this case). API keys can also be passed as environment variables (`-e OPENAI_API_KEY=sk-XXX`) instead of `--key`.
+
+To build the image yourself instead of pulling:
+
+```shell
+docker build --tag bilingual_book_maker .
+docker run --rm -v /path/to/your/books:/book bilingual_book_maker --book_name /book/animal_farm.epub --key sk-XXX --language zh-hans
 ```
 
 ## Notes

--- a/tests/test_cli_documentation.py
+++ b/tests/test_cli_documentation.py
@@ -101,7 +101,16 @@ def test_help_renders():
 # own flags in the docker section, and the shell placeholders the skill uses
 # in its recipes.
 _FOREIGN_FLAGS = frozenset(
-    {"--help", "--rm", "--name", "--mount", "--tag", "--flag", "--git-common-dir"}
+    {
+        "--help",
+        "--rm",
+        "--name",
+        "--mount",
+        "--tag",
+        "--user",
+        "--flag",
+        "--git-common-dir",
+    }
 )
 
 # Every file an operator or an agent reads to decide what to type. The skill


### PR DESCRIPTION
> update Docker usage 

Right now no Docker image of bbm is ever published — the "Release and Build Docker Image" workflow only releases to PyPI, so the README's Docker section asks users to build the image themselves, and its examples predate the current CLI flags. This PR makes the image a first-class, automatically published artifact.

## What this does

**`.github/workflows/docker.yaml` (new)** — builds `linux/amd64` + `linux/arm64` with buildx and pushes to `ghcr.io/yihong0618/bilingual_book_maker`:
- every push to `main` (i.e. every merged PR) → `latest` + `sha-…`
- every version tag → semver tag (alongside the PyPI release)
- pull requests → build-only validation, no push, no credentials needed (fork-safe)

Auth is the built-in `GITHUB_TOKEN` with `packages: write` — **nothing to configure, no secrets to add**. Layer cache uses `type=gha`, so routine rebuilds are fast. One note: after the first successful publish, check the package's visibility under Settings → Packages and flip it to *public* once — GitHub sometimes defaults new packages to private.

**`Dockerfile` (rewritten)**
- `python:3.12-slim`; the `apt-get update` layer is gone entirely — every dependency in the hash-pinned `requirements.txt` ships manylinux wheels for both architectures, so no compiler and no apt packages are needed, and pip installs in hash-checking mode.
- dependencies install as their own layer, code copies after → editing code no longer re-downloads 986 pinned packages.
- runs as a non-root user (uid 1000), with OCI labels so the GHCR package links back to this repo.
- `ENTRYPOINT` passes argv through verbatim and `CMD` defaults to `--help` — every `make_book.py` flag works unchanged, and a bare `docker run` prints usage instead of an error.
- non-root surfaced a real bug: the CLI unconditionally creates CWD-relative `log/` (`epub_loader.py`) and `batch_files/` (openai batch route) directories, which fails with `PermissionError` for any non-root user in a read-only `/app`. The image pre-creates both as group-root-writable, so the default user *and* `docker run --user <uid>` both work. (A follow-up could move those paths to a temp/XDG location in the code itself.)

**`.dockerignore`** — now an allowlist: only `book_maker/`, `make_book.py` and `requirements.txt` enter the build context (1.1MB, previously the entire repo including test books).

**`release.yaml`** — renamed to "Release PyPI"; the Docker half of its old name now actually exists, in `docker.yaml`.

**README + README-CN** — the Docker section now leads with `docker pull ghcr.io/yihong0618/bilingual_book_maker:latest`, uses the current flag surface (`--key` / `--api_format`, including a no-key `--api_format google` test example), documents the non-root behaviour, and keeps local build as a fallback. README-CN previously had no Docker section at all; it now carries the same section in Chinese.

## Tested

- image builds at 455MB; bare run and `--help` print identical usage, exit 0
- full end-to-end run inside the container over the free Google route (`--api_format google --test --test_num 8 --language zh-hans`): valid bilingual epub written through the bind mount — ids and internal links intact, each translation a sibling of its original with the same tag/class, no marker residue
- non-root write-through verified as uid 1000 and as `--user 1001`
- dual-arch `buildx build --platform linux/amd64,linux/arm64` resolves every wheel on both architectures
- `actionlint` clean on both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
